### PR TITLE
[LayerTree] hide items with hideInLegend property by default

### DIFF
--- a/src/components/LayerTree/LayerTree.js
+++ b/src/components/LayerTree/LayerTree.js
@@ -82,7 +82,7 @@ const defaultProps = {
   layerService: undefined,
   className: 'rs-layer-tree',
   padding: 30,
-  isItemHidden: () => false,
+  isItemHidden: item => item.get('hideInLegend'),
   getParentClassName: () => undefined,
   renderItem: null,
   renderItemContent: null,


### PR DESCRIPTION
The hideInLegend property is used in the demos and example data. The need for a isItemHidden function is not really documented so it's a hassle to figure out why it's not working out of the box.
I guess hiding also the baselayers by default would be to invasive