### PR TITLE
reduce CPU usage  of Geolocation Component

### DIFF
--- a/src/components/Geolocation/Geolocation.js
+++ b/src/components/Geolocation/Geolocation.js
@@ -75,6 +75,7 @@ class Geolocation extends PureComponent {
 
     this.state = {
       active: false,
+      point: undefined,
     };
   }
 
@@ -116,6 +117,7 @@ class Geolocation extends PureComponent {
   }
 
   activate(position) {
+    const { point } = this.state;
     const { map } = this.props;
 
     const code = map
@@ -127,10 +129,17 @@ class Geolocation extends PureComponent {
       'EPSG:4326',
       code,
     );
-
-    const point = new Point(pos);
-    this.highlight(point);
-    this.layer.setMap(map);
+    if (!point) {
+      var tmpPoint = new Point(pos);
+      this.setState({
+        point: tmpPoint,
+      });
+      this.highlight(tmpPoint);
+      this.layer.setMap(map);
+    } else {
+      point.setCoordinates(pos);
+    }
+    
     if (this.isCentered) {
       map.getView().setCenter(pos);
     }

--- a/src/components/Geolocation/Geolocation.js
+++ b/src/components/Geolocation/Geolocation.js
@@ -152,21 +152,7 @@ class Geolocation extends PureComponent {
   highlight(point) {
     const { colorOrStyleFunc } = this.props;
 
-    let decrease = true;
-    let opacity = 0.5;
-    let rotation = 0;
     let feature;
-
-    window.clearInterval(this.interval);
-    this.interval = window.setInterval(() => {
-      rotation += 0.03;
-      decrease = opacity < 0.1 ? false : decrease;
-      decrease = opacity > 0.5 ? true : decrease;
-      opacity += decrease ? -0.03 : 0.03;
-      if (feature) {
-        feature.changed();
-      }
-    }, 50);
 
     feature = new Feature({
       geometry: point,
@@ -175,6 +161,21 @@ class Geolocation extends PureComponent {
 
     if (Array.isArray(colorOrStyleFunc)) {
       const color = colorOrStyleFunc;
+
+      let decrease = true;
+      let opacity = 0.5;
+      let rotation = 0;
+
+      window.clearInterval(this.interval);
+      this.interval = window.setInterval(() => {
+        rotation += 0.03;
+        decrease = opacity < 0.1 ? false : decrease;
+        decrease = opacity > 0.5 ? true : decrease;
+        opacity += decrease ? -0.03 : 0.03;
+        if (feature) {
+          feature.changed();
+        }
+      }, 50);
 
       feature.setStyle(() => {
         const circleStyle = new Style({

--- a/src/components/Geolocation/Geolocation.js
+++ b/src/components/Geolocation/Geolocation.js
@@ -113,6 +113,7 @@ class Geolocation extends PureComponent {
 
     this.setState({
       active: false,
+      point: undefined,
     });
   }
 


### PR DESCRIPTION
I noticed a very high CPU usage of the geolocation component. Even after I disabled all animations, I still see about 30% CPU usage with no updates and 60% with 1 update/s.
Reasons are
* the layer, style and feature are recreated for every location Update
* even if you provide your own style function, the timer for the animation is still created.

We can instead reuse the layer, style and just update the location.
With this patch I'm down to about 0% CPU usage with no update and 10% at 1 update/s.

With animations enabled you will not see so much improvments.