### PR TITLE
[geolocation] make it possible to pass a real function as style

### DIFF
--- a/src/components/Geolocation/Geolocation.js
+++ b/src/components/Geolocation/Geolocation.js
@@ -203,8 +203,10 @@ class Geolocation extends PureComponent {
           circleStyle,
         ];
       });
-    } else {
+    } else if (colorOrStyleFunc instanceof Style) {
       feature.setStyle(colorOrStyleFunc);
+    } else {
+      feature.setStyle(colorOrStyleFunc(feature));
     }
 
     this.layer.getSource().clear();


### PR DESCRIPTION
Motivation:
I use a directional icon for the location and rotate it by the device's
compass. After a compass change, I update the style.
Afterwards you have to call feature.changed() so the change gets processed.

For this reason I need to prove a real function to the geolocation
component, which receives the feature as a parameter and returns a style.

This patch also handles the case that someone passes a plain style as it
was possible before.