### PR TITLE
[Mapbox-Layer] make fadeDuration configurable

### DIFF
--- a/src/layers/MapboxLayer.js
+++ b/src/layers/MapboxLayer.js
@@ -122,6 +122,8 @@ export default class MapboxLayer extends Layer {
       pitchWithRotate: false,
       scrollZoom: false,
       touchZoomRotate: false,
+      fadeDuration:
+        'fadeDuration' in this.options ? this.options.fadeDuration : 300,
       // Needs to be true to able to export the canvas, but could lead to performance issue on mobile.
       preserveDrawingBuffer: this.options.preserveDrawingBuffer || false,
     });


### PR DESCRIPTION
I like the fade animations IF I'm using a very fast computer.
In general I care more about loading times, performance and and battery.

For this reason I want to disable the fade animations in my project.
Google-Maps also doesn't do fading, but bing maps does.

This improves the initial loading times and zooming alot on weak devies.

The default stays 300ms (https://docs.mapbox.com/mapbox-gl-js/api/)


@mhaertwig You shoud use this option in the moco picture generator. I guess trafimage would benefit alot from this but of course it doesn't look so slick anymore