### PR TITLE
KML fillPattern

### DIFF
--- a/src/utils/KML.js
+++ b/src/utils/KML.js
@@ -306,6 +306,12 @@ const writeFeatures = (layer, featureProjection) => {
       }
     }
 
+    if (newStyle.fill && newStyle.fill.getColor() instanceof CanvasPattern) {
+      // eslint-disable-next-line no-console
+      clone.set('fillPattern', f.get('fillPattern'));
+      newStyle.fill = null;
+    }
+
     // If only text is displayed we must specify an
     // image style with scale=0
     if (newStyle.text && !newStyle.image) {

--- a/src/utils/KML.js
+++ b/src/utils/KML.js
@@ -307,7 +307,6 @@ const writeFeatures = (layer, featureProjection) => {
     }
 
     if (newStyle.fill && newStyle.fill.getColor() instanceof CanvasPattern) {
-      // eslint-disable-next-line no-console
       clone.set('fillPattern', f.get('fillPattern'));
       newStyle.fill = null;
     }

--- a/src/utils/KML.js
+++ b/src/utils/KML.js
@@ -306,7 +306,8 @@ const writeFeatures = (layer, featureProjection) => {
       }
     }
 
-    if (newStyle.fill && newStyle.fill.getColor() instanceof CanvasPattern) {
+    // In case a fill pattern should be applied (use fillPattern attribute to store pattern id, color etc)
+    if (newStyle.fill && f.get('fillPattern')) {
       clone.set('fillPattern', f.get('fillPattern'));
       newStyle.fill = null;
     }

--- a/src/utils/KML.test.js
+++ b/src/utils/KML.test.js
@@ -150,5 +150,46 @@ describe('KML', () => {
       });
       expectWriteResult(feats, str);
     });
+
+    test('should add fillPattern attribute to feature if specified in extended data.', () => {
+      const str = `
+        <kml ${xmlns}>
+          <Document>
+            <name>lala</name>
+            <Placemark>
+                <description></description>
+                <Style>
+                    <LineStyle>
+                        <color>ff0000eb</color>
+                        <width>2</width>
+                    </LineStyle>
+                </Style>
+                <ExtendedData>
+                    <Data name="fillPattern">
+                        <value>{"id":3,"color":[235,0,0,1]}</value>
+                    </Data>
+                    <Data name="lineDash">
+                        <value>1,1</value>
+                    </Data>
+                </ExtendedData>
+                <Polygon>
+                    <outerBoundaryIs>
+                        <LinearRing>
+                            <coordinates>8.521549619962451,47.38072787729837,0 8.529446043302295,47.37584574107993,0 8.531484522153614,47.382151748542725,0 8.521549619962451,47.38072787729837,0</coordinates>
+                        </LinearRing>
+                    </outerBoundaryIs>
+                </Polygon>
+            </Placemark>
+        </Document>
+      </kml>
+      `;
+      const feats = KML.readFeatures(str);
+      expect(feats.length).toBe(1);
+
+      // Polygon
+      const feature = feats[0];
+      expect(feature.get('fillPattern')).toBe('{"id":3,"color":[235,0,0,1]}');
+      expectWriteResult(feats, str);
+    });
   });
 });

--- a/src/utils/KML.test.js
+++ b/src/utils/KML.test.js
@@ -151,7 +151,7 @@ describe('KML', () => {
       expectWriteResult(feats, str);
     });
 
-    test('should add fillPattern attribute to feature if specified in extended data.', () => {
+    test('should add fillPattern attribute to feature if specified in extended data and apply correct outline styles.', () => {
       const str = `
         <kml ${xmlns}>
           <Document>
@@ -175,7 +175,7 @@ describe('KML', () => {
                 <Polygon>
                     <outerBoundaryIs>
                         <LinearRing>
-                            <coordinates>8.521549619962451,47.38072787729837,0 8.529446043302295,47.37584574107993,0 8.531484522153614,47.382151748542725,0 8.521549619962451,47.38072787729837,0</coordinates>
+                            <coordinates>8.521,47.381,0 8.529,47.375,0 8.531,47.382,0 8.521,47.381,0</coordinates>
                         </LinearRing>
                     </outerBoundaryIs>
                 </Polygon>
@@ -184,10 +184,15 @@ describe('KML', () => {
       </kml>
       `;
       const feats = KML.readFeatures(str);
+      const styles = feats[0].getStyle();
       expect(feats.length).toBe(1);
+      expect(styles.length).toBe(1);
 
       // Polygon
       const feature = feats[0];
+      const outlineStyle = styles[0].getStroke();
+      expect(outlineStyle.getColor()).toEqual([235, 0, 0, 1]);
+      expect(outlineStyle.getWidth()).toEqual(2);
       expect(feature.get('fillPattern')).toBe('{"id":3,"color":[235,0,0,1]}');
       expectWriteResult(feats, str);
     });


### PR DESCRIPTION
- Added kml writing capability for CanvasPatterns
- When detecting a CanvasPattern in a Fill style  fillPattern: <string> is saved in the feature properties
- This string can be used to create custom CanvasPatterns in the Client app