### PR TITLE
KML zIndex fix

### DIFF
--- a/src/utils/KML.js
+++ b/src/utils/KML.js
@@ -156,7 +156,7 @@ const sanitizeFeature = (feature) => {
     }
 
     if (feature.get('zIndex')) {
-      style.setZIndex(feature.get('zIndex'));
+      style.setZIndex(parseInt(feature.get('zIndex'), 10));
     }
 
     fill = undefined;

--- a/src/utils/KML.js
+++ b/src/utils/KML.js
@@ -155,6 +155,10 @@ const sanitizeFeature = (feature) => {
       }
     }
 
+    if (feature.get('zIndex')) {
+      style.setZIndex(feature.get('zIndex'));
+    }
+
     fill = undefined;
     stroke = undefined;
 
@@ -167,6 +171,7 @@ const sanitizeFeature = (feature) => {
         zIndex: style.getZIndex(),
       }),
     ];
+
     feature.setStyle(styles);
   }
 
@@ -277,6 +282,10 @@ const writeFeatures = (layer, featureProjection) => {
       image: styles[0].getImage(),
       zIndex: styles[0].getZIndex(),
     };
+
+    if (newStyle.zIndex) {
+      clone.set('zIndex', newStyle.zIndex);
+    }
 
     // If we see spaces at the beginning or at the end we add a empty
     // white space at the beginning and at the end.

--- a/src/utils/KML.test.js
+++ b/src/utils/KML.test.js
@@ -211,5 +211,41 @@ describe('KML', () => {
       });
       expectWriteResult(feats, str);
     });
+
+    test('should add zIndex to the feature style.', () => {
+      const str = `
+      <kml ${xmlns}>
+        <Document>
+            <name>lala</name>
+            <Placemark>
+                <description></description>
+                <Style>
+                    <IconStyle>
+                        <scale>0.5</scale>
+                        <Icon>
+                            <href>https://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+                            <gx:w>64</gx:w>
+                            <gx:h>64</gx:h>
+                        </Icon>
+                        <hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+                    </IconStyle>
+                </Style>
+                <ExtendedData>
+                    <Data name="zIndex">
+                        <value>1</value>
+                    </Data>
+                </ExtendedData>
+                <Point>
+                    <coordinates>0,0,0</coordinates>
+                </Point>
+            </Placemark>
+        </Document>
+      </kml>
+      `;
+      const feats = KML.readFeatures(str);
+      const style = feats[0].getStyle()[0];
+      expect(style.getZIndex()).toBe(1);
+      expectWriteResult(feats, str);
+    });
   });
 });


### PR DESCRIPTION
The current kml does not properly write the kml index of the feature styles
Fixed by adding zIndex to extended data