### PR TITLE
Update BLS to 0.3.0

### DIFF
--- a/src/components/BaseLayerSwitcher/BaseLayerSwitcher.js
+++ b/src/components/BaseLayerSwitcher/BaseLayerSwitcher.js
@@ -172,7 +172,9 @@ function BaseLayerSwitcher({
           const activeClass =
             layerName === currentLayer.getName() ? ' rs-active' : '';
           const imageStyle = getImageStyle(
-            layerImages ? layerImages[`${layer.key}`] : layer.previewImage,
+            layerImages
+              ? layerImages[`${layer.key}`]
+              : layer.get('previewImage'),
           );
           return (
             <div

--- a/src/components/BaseLayerSwitcher/BaseLayerSwitcher.js
+++ b/src/components/BaseLayerSwitcher/BaseLayerSwitcher.js
@@ -118,7 +118,11 @@ function BaseLayerSwitcher({
   };
 
   /* Get next image for closed button */
-  const nextImage = getNextImage(currentLayer, baseLayers, images);
+  const nextImage = getNextImage(
+    currentLayer || baseLayers[0],
+    baseLayers,
+    images,
+  );
 
   useEffect(() => {
     /* Ensure correct layer is active on app load */

--- a/src/components/BaseLayerSwitcher/BaseLayerSwitcher.js
+++ b/src/components/BaseLayerSwitcher/BaseLayerSwitcher.js
@@ -102,7 +102,7 @@ function BaseLayerSwitcher({
   /* Images are loaded from props if provided, fallback from layer */
   const images = layerImages
     ? Object.keys(layerImages).map((layerImage) => layerImages[layerImage])
-    : baseLayers.map((layer) => layer.previewImage);
+    : baseLayers.map((layer) => layer.get('previewImage'));
 
   const openClass = switcherOpen ? ' rs-open' : '';
   const closedClass = isClosed ? ' rs-closed' : '';
@@ -145,7 +145,9 @@ function BaseLayerSwitcher({
   }
 
   /* Move visible layer to front of array */
-  baseLayers.sort((a) => (a.key === currentLayer.key ? -1 : 1));
+  if (currentLayer) {
+    baseLayers.sort((a) => (a.key === currentLayer.key ? -1 : 1));
+  }
 
   const toggleBtn = (
     <div

--- a/src/components/BaseLayerSwitcher/BaseLayerSwitcher.js
+++ b/src/components/BaseLayerSwitcher/BaseLayerSwitcher.js
@@ -97,7 +97,9 @@ function BaseLayerSwitcher({
   const baseLayers = layers.filter((layer) => layer.getIsBaseLayer());
   const [switcherOpen, setSwitcherOpen] = useState(false);
   const [isClosed, setIsClosed] = useState(true);
-  const [currentLayer, setCurrentLayer] = useState(getVisibleLayer(baseLayers));
+  const [currentLayer, setCurrentLayer] = useState(
+    getVisibleLayer(baseLayers) || baseLayers[0],
+  );
 
   /* Images are loaded from props if provided, fallback from layer */
   const images = layerImages
@@ -118,18 +120,14 @@ function BaseLayerSwitcher({
   };
 
   /* Get next image for closed button */
-  const nextImage = getNextImage(
-    currentLayer || baseLayers[0],
-    baseLayers,
-    images,
-  );
+  const nextImage = getNextImage(currentLayer, baseLayers, images);
 
   useEffect(() => {
     /* Ensure correct layer is active on app load */
     if (currentLayer !== getVisibleLayer(baseLayers)) {
-      setCurrentLayer(getVisibleLayer(baseLayers));
+      setCurrentLayer(getVisibleLayer(baseLayers) || baseLayers[0]);
     }
-  }, [currentLayer]);
+  }, [currentLayer, baseLayers]);
 
   useEffect(() => {
     /* Used for correct layer image render with animation */

--- a/src/components/BaseLayerSwitcher/BaseLayerSwitcher.test.js
+++ b/src/components/BaseLayerSwitcher/BaseLayerSwitcher.test.js
@@ -44,6 +44,17 @@ describe('BaseLayerSwitcher', () => {
     expect(comp.props().layers[0].getVisible()).toBe(true);
   });
 
+  test('omits layer sorting when currentLayer is undefined', () => {
+    const layers = ConfigReader.readConfig(data);
+    const baseLayers = layers.filter((layer) => layer.getIsBaseLayer());
+    baseLayers.forEach((layer) => layer.setVisible(false));
+    const comp = mountComp(baseLayers);
+    expect(comp.props().layers.find((layer) => layer.getVisible())).toBe(
+      undefined,
+    );
+    expect(comp.props().layers).toStrictEqual(baseLayers);
+  });
+
   test('adds close button when opening the switcher', () => {
     const comp = mountComp(data);
     expect(comp.find('.rs-base-layer-switcher-button').length).toBe(1);


### PR DESCRIPTION
# How to

Updates: 
- Updated baselayer switcher to get fallback image from layer properties via layer.get('previewImage') rather than layer.previewImage
- Fixed a bug causing crash when trying to sort the layers, but the currentLayer is undefined
- Added default layer to getNextImage() when currentLayer is undefined
- Added baseLayers to useEffect hook for setting the currentLayer (on topic change in trafimage the baselayers are not always updated in time for the currentLayer to be set
 correctly, results in undefined)

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
