### PR TITLE
Don't set a default tabIndex on the BasicMap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "0.3.5",
+  "version": "0.3.6-beta.1",
   "license": "MIT",
   "dependencies": {
     "query-string": "^6.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "0.3.6-beta.1",
+  "version": "0.3.6-beta.2",
   "license": "MIT",
   "dependencies": {
     "query-string": "^6.11.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "peerDependencies": {
     "mapbox-gl": "^1.2.0",
-    "ol": "^6.0.1",
+    "ol": "^6.3.1",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"
   },
@@ -54,7 +54,7 @@
     "lint-staged": "^10.0.10",
     "mapbox-gl": "1.9.1",
     "node-sass": "^4.11.0",
-    "ol": "6.1.1",
+    "ol": "6.3.1",
     "prettier": "^2.0.2",
     "proj4": "^2.6.0",
     "prop-types": "^15.6.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "url-loader": "^4.0.0",
     "vinyl-fs": "^3.0.3",
     "webpack": "^4.42.1",
-    "xml-beautifier": "^0.4.2"
+    "xml-beautifier": "^0.4.3"
   },
   "scripts": {
     "build": "buble --no modules,asyncAwait -i src -o build --objectAssign Object.assign --sourcemap && cp package.json README.md LICENSE build && cp -rf src/images build",

--- a/src/components/BaseLayerSwitcher/README.md
+++ b/src/components/BaseLayerSwitcher/README.md
@@ -29,6 +29,7 @@ const layerImages = {
     center={center}
     zoom={6}
     layers={layers}
+    tabIndex={0}
   />
   <BaseLayerSwitcher
     layers={layers}

--- a/src/components/BaseLayerToggler/README.md
+++ b/src/components/BaseLayerToggler/README.md
@@ -21,6 +21,7 @@ const layerService = new LayerService(layers);
     center={center}
     zoom={6}
     layers={layers}
+    tabIndex={0}
   />
   <BaseLayerToggler
     map={map}

--- a/src/components/BasicMap/BasicMap.js
+++ b/src/components/BasicMap/BasicMap.js
@@ -100,7 +100,7 @@ const defaultProps = {
   onFeaturesHover: undefined,
   onMapMoved: undefined,
   resolution: undefined,
-  tabIndex: 0,
+  tabIndex: undefined,
   ariaLabel: 'map',
   viewOptions: {
     minZoom: 0,

--- a/src/components/BasicMap/README.md
+++ b/src/components/BasicMap/README.md
@@ -17,5 +17,5 @@ const layers = ConfigReader.readConfig([{
   },
 }]);
 
-<BasicMap layers={layers} />;
+<BasicMap layers={layers} tabIndex={0} />;
 ```

--- a/src/components/CanvasSaveButton/README.md
+++ b/src/components/CanvasSaveButton/README.md
@@ -26,6 +26,7 @@ function CanvasSaveButtonExample() {
         center={[874105.13, 6106172.77]}
         zoom={10}
         layers={layers}
+        tabIndex={0}
       />
       <CanvasSaveButton
         map={map}

--- a/src/components/FeatureExportButton/README.md
+++ b/src/components/FeatureExportButton/README.md
@@ -72,6 +72,7 @@ class FeatureExportButtonExample extends React.Component {
           zoom={9}
           map={this.map}
           layers={this.layers}
+          tabIndex={0}
         />
         <div>
           <FeatureExportButton layer={this.layers[1]}>

--- a/src/components/FitExtent/README.md
+++ b/src/components/FitExtent/README.md
@@ -16,7 +16,7 @@ const extent = [-15380353.1391, 2230738.2886, -6496535.908, 6927029.2369];
 function FitExtentExample() {
   return (
     <div>
-      <BasicMap map={map} layers={layers} />
+      <BasicMap map={map} layers={layers} tabIndex={0} />
       <FitExtent map={map} extent={extent}>fit!</FitExtent>
     </div>
   );

--- a/src/components/Geolocation/README.md
+++ b/src/components/Geolocation/README.md
@@ -15,7 +15,7 @@ const layers = ConfigReader.readConfig(treeData);
 function GeolocationExample() {
   return (
     <div className="rs-geolocation-example">
-      <BasicMap map={map} layers={layers} />
+      <BasicMap map={map} layers={layers} tabIndex={0} />
       <Geolocation map={map} />
     </div>
   );

--- a/src/components/LayerTree/README.md
+++ b/src/components/LayerTree/README.md
@@ -18,7 +18,7 @@ const layerService = new LayerService(layers);
 function LayerTreeExample() {
   return (
     <div className="rs-layer-tree-example">
-      <BasicMap map={map} layers={layers} center={center} zoom={3} />
+      <BasicMap map={map} layers={layers} center={center} zoom={3} tabIndex={0} />
       <LayerTree layerService={layerService} />
     </div>
   );

--- a/src/components/MousePosition/README.md
+++ b/src/components/MousePosition/README.md
@@ -16,7 +16,7 @@ const layers = ConfigReader.readConfig(treeData);
 function MousePositionExample() {
   return (
     <div className="rs-mouse-position-example">
-      <BasicMap map={map} center={center} zoom={6} layers={layers} />
+      <BasicMap map={map} center={center} zoom={6} layers={layers} tabIndex={0} />
       <MousePosition
         map={map}
         projections={[

--- a/src/components/NorthArrow/NorthArrow.test.js
+++ b/src/components/NorthArrow/NorthArrow.test.js
@@ -96,9 +96,9 @@ describe('NorthArrow', () => {
   test('should remove post render event on unmount', () => {
     const wrapper = mount(<NorthArrow map={olMap} rotationOffset={-10} />);
     // eslint-disable-next-line no-underscore-dangle
-    expect(olMap.listeners_.postrender.length).toBe(3);
+    expect(olMap.listeners_.postrender.length).toBe(4);
     wrapper.unmount();
     // eslint-disable-next-line no-underscore-dangle
-    expect(olMap.listeners_.postrender.length).toBe(2);
+    expect(olMap.listeners_.postrender.length).toBe(3);
   });
 });

--- a/src/components/NorthArrow/README.md
+++ b/src/components/NorthArrow/README.md
@@ -56,6 +56,7 @@ const map = new OLMap({
     center={center}
     zoom={17}
     layers={layers}
+    tabIndex={0}
   />
   <NorthArrow
     map={map}

--- a/src/components/Permalink/README.md
+++ b/src/components/Permalink/README.md
@@ -18,7 +18,7 @@ const populationLayer = layerService.getLayer('USA Population Density');
 const baseLayers = layerService.getBaseLayers();
 
 <div className="rs-permalink-example">
-  <BasicMap map={map} layers={layers} />
+  <BasicMap map={map} layers={layers} tabIndex={0} />
   <Permalink
     map={map}
     layerService={layerService}

--- a/src/components/Popup/README.md
+++ b/src/components/Popup/README.md
@@ -95,6 +95,7 @@ class PopupExample extends React.Component {
           zoom={17}
           layers={this.layers}
           onFeaturesClick={this.onFeaturesClick}
+          tabIndex={0}
         />
         <ResizeHandler observe={this} />
         <Popup

--- a/src/components/ScaleLine/README.md
+++ b/src/components/ScaleLine/README.md
@@ -31,6 +31,7 @@ class ScaleLineExample extends Component {
           map={this.map}
           zoom={3}
           layers={this.layers}
+          tabIndex={0}
         />
         <ScaleLine map={this.map} />
       </div>

--- a/src/components/Zoom/README.md
+++ b/src/components/Zoom/README.md
@@ -15,7 +15,7 @@ const layers = ConfigReader.readConfig(treeData);
 function ZoomExample() {
   return (
     <div className="rs-zoom-example">
-      <BasicMap map={map} layers={layers} />
+      <BasicMap map={map} layers={layers} tabIndex={0} />
       <Zoom map={map} zoomSlider />
     </div>
   );

--- a/src/utils/KML.js
+++ b/src/utils/KML.js
@@ -104,7 +104,7 @@ const sanitizeFeature = (feature) => {
         });
       }
 
-      // We replace empty white spaces used to keep mormal spaces before and after the name.
+      // We replace empty white spaces used to keep normal spaces before and after the name.
       let name = feature.get('name');
       if (/\u200B/g.test(name)) {
         name = name.replace(/\u200B/g, '');
@@ -345,7 +345,7 @@ const writeFeatures = (layer, featureProjection) => {
     }
 
     // In case a fill pattern should be applied (use fillPattern attribute to store pattern id, color etc)
-    if (newStyle.fill && f.get('fillPattern')) {
+    if (f.get('fillPattern')) {
       clone.set('fillPattern', JSON.stringify(f.get('fillPattern')));
       newStyle.fill = null;
     }

--- a/src/utils/KML.test.js
+++ b/src/utils/KML.test.js
@@ -42,9 +42,6 @@ describe('KML', () => {
                     <color>ff056600</color>
                     <width>1</width>
                   </LineStyle>
-                  <PolyStyle>
-                    <color>ffffffff</color>
-                  </PolyStyle>
                 </Style>
                 <ExtendedData>
                   <Data name="lineDash"><value>40,40</value></Data>
@@ -101,7 +98,7 @@ describe('KML', () => {
           <Document>
             <name>lala</name>
             <Placemark>
-              <name>\u200B   bar  \u200B</name>
+              <name>   bar  </name>
               <Style>
                 <IconStyle>
                   <scale>0</scale>
@@ -148,7 +145,7 @@ describe('KML', () => {
 
       // Text
       const style = styles[0].getText();
-      expect(style.getText()).toBe('   bar  ');
+      expect(style.getText()).toBe('bar'); // spaces are trimmed.
       expect(style.getFont()).toEqual('bold 16px arial');
       expect(style.getFill()).toEqual({ color_: [32, 52, 126, 1] });
       expect(style.getScale()).toEqual(2);
@@ -175,6 +172,9 @@ describe('KML', () => {
                         <color>ff0000eb</color>
                         <width>2</width>
                     </LineStyle>
+                    <PolyStyle>
+                      <fill>0</fill>
+                    </PolyStyle>
                 </Style>
                 <ExtendedData>
                     <Data name="fillPattern">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,11 +1360,6 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@openlayers/pepjs@^0.5.3":
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/@openlayers/pepjs/-/pepjs-0.5.3.tgz#298c5994cc12de5f149f841affdd8a3e506228b5"
-  integrity sha512-Bgvi5c14BS0FJWyYWWFstNEnXsB30nK8Jt8hkAAdqr7E0gDdBBWVDglF3Ub19wTxvgJ/CVHyTY6VuCtnyRzglg==
-
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -4246,6 +4241,11 @@ elliptic@^6.0.0, elliptic@^6.5.2:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
+
+elm-pep@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/elm-pep/-/elm-pep-1.0.6.tgz#768b6b0cc59ce6b608d9d14c87ef8c2c0936f6ec"
+  integrity sha512-1DJ6ReFk8+GtgoqRiEhBo28K69Rxe9Bfc7h16+1VMQT2KlCuPBYj5W33OYa2AZpqkuqCBLhcNzO10zxJVakapA==
 
 "emoji-regex@>=6.0.0 <=6.1.1":
   version "6.1.1"
@@ -8694,12 +8694,12 @@ obuf@^1.0.0, obuf@^1.1.2:
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
-ol@6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/ol/-/ol-6.1.1.tgz#7f8ada284344a5872d552205de558ed4a904cd27"
-  integrity sha512-0dL3i3eJqgOpqIjDKEY3grkeQnjAYfV5L/JCxhOu4SxiaizRwFrFgeas6LILRoxKa03jhQFbut2r2bbgcLGQeA==
+ol@6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/ol/-/ol-6.3.1.tgz#11fcb987e632efb9f75f87fe8d85f50764543843"
+  integrity sha512-cSSYizzUJQ7AhFSrLPAKopjDXPCHtJsXSmjf3xutPG+iyBeD9IOepQGSgpOSZavPI1gsYh9wowiH+NZwVJ/NYQ==
   dependencies:
-    "@openlayers/pepjs" "^0.5.3"
+    elm-pep "^1.0.4"
     pbf "3.2.1"
     pixelworks "1.1.0"
     rbush "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13075,7 +13075,7 @@ x-is-string@^0.1.0:
   resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
   integrity sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=
 
-xml-beautifier@^0.4.2:
+xml-beautifier@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/xml-beautifier/-/xml-beautifier-0.4.3.tgz#2d5e320e19bf70ac7343c01135a1f99df08b4c37"
   integrity sha512-jtqVgG2mXX+mZYSq80tPWBcrtPGL3JwCtcME52c7Aau1R34quuJw86R9A+KFO7F6EQAaagUmMXGhDRKGV3UXhw==


### PR DESCRIPTION
# How to
openlayers tabIndex behavior changed a bit due to:
https://github.com/openlayers/openlayers/pull/10291/files

When a tabIndex is set we now have to focus the map to be able to interact with it.
Thus a default map without TabIndex seems to be better.
<!--  Please provide a test link and quick description how to see the change -->

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
