### PR TITLE
fix setting rotation to 0 in MapBox Layer

### DIFF
--- a/src/layers/MapboxLayer.js
+++ b/src/layers/MapboxLayer.js
@@ -58,7 +58,7 @@ export default class MapboxLayer extends Layer {
 
         // adjust view parameters in mapbox
         const { rotation } = viewState;
-        if (rotation && this.renderState.rotation !== rotation) {
+        if (rotation != null && this.renderState.rotation !== rotation) {
           this.mbMap.rotateTo((-rotation * 180) / Math.PI, {
             animate: false,
           });


### PR DESCRIPTION
# How to

Resetting the rotation to zero with  `this.map.getView().setRotation(0)` did not work in the MapBox-Layer. 
We have to check that `rotation` is not equal to null/undefined instead of false

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [ ] IE11 tested.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
