### PR TITLE
add hitTolerance on featureClicked

### DIFF
--- a/src/components/BasicMap/BasicMap.js
+++ b/src/components/BasicMap/BasicMap.js
@@ -49,6 +49,9 @@ const propTypes = {
    */
   onFeaturesClick: PropTypes.func,
 
+  /** Hit-detection tolerance in pixels. Pixels inside the radius around the given position will be checked for features. */
+  featuresClickHitTolerance: PropTypes.number,
+
   /**
    * Callback when a [ol/Feature](https://openlayers.org/en/latest/apidoc/module-ol_Feature-Feature.html) is hovered.
    * @param {OLFeature[]} features An array of [ol/Feature](https://openlayers.org/en/latest/apidoc/module-ol_Feature-Feature.html).
@@ -97,6 +100,7 @@ const defaultProps = {
   layers: [],
   map: null,
   onFeaturesClick: undefined,
+  featuresClickHitTolerance: 0,
   onFeaturesHover: undefined,
   onMapMoved: undefined,
   resolution: undefined,
@@ -154,6 +158,7 @@ class BasicMap extends PureComponent {
     const {
       onMapMoved,
       onFeaturesClick,
+      featuresClickHitTolerance,
       onFeaturesHover,
       layers,
       extent,
@@ -190,7 +195,9 @@ class BasicMap extends PureComponent {
 
     if (onFeaturesClick) {
       this.singleClickRef = this.map.on('singleclick', (evt) => {
-        const features = evt.map.getFeaturesAtPixel(evt.pixel);
+        const features = evt.map.getFeaturesAtPixel(evt.pixel, {
+          hitTolerance: featuresClickHitTolerance,
+        });
         onFeaturesClick(features || [], evt);
       });
     }


### PR DESCRIPTION
# How to

clicking on a line-feature on a mobile-phone is really hard. Introduce a hitTolerance property to make it easier.
Default stays the same at 0.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [ x Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [ ] IE11 tested.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
