### PR TITLE
KML zIndex Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "0.3.8-beta.2",
+  "version": "0.3.7",
   "license": "MIT",
   "dependencies": {
     "abortcontroller-polyfill": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "0.3.7",
+  "version": "0.3.8-beta.2",
   "license": "MIT",
   "dependencies": {
     "abortcontroller-polyfill": "^1.4.0",

--- a/src/utils/KML.js
+++ b/src/utils/KML.js
@@ -78,6 +78,10 @@ const sanitizeFeature = (feature) => {
     stroke = undefined;
   }
 
+  if (feature.get('zIndex')) {
+    style.setZIndex(parseInt(feature.get('zIndex'), 10));
+  }
+
   // if the feature is a Point and we are offline, we use default vector
   // style.
   // if the feature is a Point and has a name with a text style, we
@@ -153,10 +157,6 @@ const sanitizeFeature = (feature) => {
       if (image instanceof Icon) {
         applyTextStyleForIcon(image, text);
       }
-    }
-
-    if (feature.get('zIndex')) {
-      style.setZIndex(parseInt(feature.get('zIndex'), 10));
     }
 
     fill = undefined;


### PR DESCRIPTION
# How to

The zIndex in the readKml method was in the wrong place and therefore only applying to labels. The set condition was moved so it applies to all geometries

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [ ] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [ ] Everything in ticket description has been fixed.
- [ ] The author of the MR has made its own review before assigning the reviewer.
- [ ] IE11 tested.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
