### PR TITLE
Fit to the extent defined as property when a maxExtent is defined.

### DIFF
--- a/src/components/BasicMap/BasicMap.js
+++ b/src/components/BasicMap/BasicMap.js
@@ -225,7 +225,7 @@ class BasicMap extends PureComponent {
       this.map.setTarget(node);
 
       // When the node is set we reinitialize the extent with the extent property.
-      if (node && extent) {
+      if (!prevState.node && node && extent) {
         this.map.getView().fit(extent);
       }
     }

--- a/src/components/BasicMap/BasicMap.js
+++ b/src/components/BasicMap/BasicMap.js
@@ -68,6 +68,9 @@ const propTypes = {
   /** The tabIndex of the map. */
   tabIndex: PropTypes.number,
 
+  /** The style of the map. */
+  style: PropTypes.object,
+
   /** HTML aria-label. */
   ariaLabel: PropTypes.string,
 
@@ -93,6 +96,7 @@ const defaultProps = {
     padding: [20, 20, 20, 20],
     maxZoom: 23,
   },
+  style: undefined,
   interactions: null,
   layers: [],
   map: null,
@@ -176,7 +180,8 @@ class BasicMap extends PureComponent {
     viewPort.style.msTouchAction = 'none';
     viewPort.setAttribute('touch-action', 'none');
 
-    if (extent) {
+    // Fit only work if the map has a size.
+    if (this.map.getSize() && extent) {
       this.map.getView().fit(extent);
     }
 
@@ -218,6 +223,11 @@ class BasicMap extends PureComponent {
 
     if (prevState.node !== node) {
       this.map.setTarget(node);
+
+      // When the node is set we reinitialize the extent with the extent property.
+      if (node && extent) {
+        this.map.getView().fit(extent);
+      }
     }
 
     if (prevProps.layers !== layers) {
@@ -303,7 +313,7 @@ class BasicMap extends PureComponent {
   }
 
   render() {
-    const { className, tabIndex, ariaLabel } = this.props;
+    const { className, tabIndex, ariaLabel, style } = this.props;
     const { node } = this.state;
     return (
       <div
@@ -312,6 +322,7 @@ class BasicMap extends PureComponent {
         role="presentation"
         aria-label={ariaLabel}
         tabIndex={tabIndex}
+        style={style}
       >
         <ResizeHandler
           maxHeightBrkpts={null}

--- a/src/components/BasicMap/BasicMap.test.js
+++ b/src/components/BasicMap/BasicMap.test.js
@@ -23,9 +23,7 @@ register(proj4);
 
 configure({ adapter: new Adapter() });
 
-const extent = [0, 0, 0, 0];
-const olView = new OLView();
-const olMap = new OLMap({ view: olView });
+const extent = [0, 0, 1000, 1000];
 const olLayers = [
   new Layer({
     name: 'foo',
@@ -35,6 +33,12 @@ const olLayers = [
 ];
 
 describe('BasicMap', () => {
+  let olMap;
+  beforeEach(() => {
+    const olView = new OLView();
+    olMap = new OLMap({ view: olView });
+  });
+
   test('should be rendered', () => {
     const setTarget = jest.spyOn(olMap, 'setTarget');
     shallow(<BasicMap map={olMap} />);
@@ -95,10 +99,10 @@ describe('BasicMap', () => {
     expect(inst.map).toBeDefined();
     expect(inst.map.getLayers().getLength()).toBe(1);
     expect(inst.map.getView().calculateExtent()).toEqual([
-      -1.8640493388513675,
-      -1.8640493388513675,
-      1.8640493388513675,
-      1.8640493388513675,
+      -119.29915768648752,
+      -119.29915768648752,
+      119.29915768648752,
+      119.29915768648752,
     ]);
   });
 


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
Open mouse position example then copy the followinf BasicMap:

```
<BasicMap  map={map} layers={layers} extent={[0, 0, 1000000, 500000]} tabIndex={0} viewOptions={{extent: [0, 0, 2000000, 2000000]}} />
```
[Mouse position example in production](https://react-spatial.netlify.app/#mouseposition) -> map is centered on viewOptions.extent (the maxExtent of the view) -> that's bad it should be centered on extent property
[Mouse position example with this PR](https://deploy-preview-595--react-spatial.netlify.app/#mouseposition)-> map is centered on extent property -> that's good

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [ ] IE11 tested.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
