### PR TITLE
Allow to update onXXX properties.

### DIFF
--- a/src/components/BasicMap/BasicMap.js
+++ b/src/components/BasicMap/BasicMap.js
@@ -171,7 +171,6 @@ class BasicMap extends PureComponent {
     const {
       onMapMoved,
       onFeaturesClick,
-      featuresClickOptions,
       onFeaturesHover,
       layers,
       extent,
@@ -208,20 +207,11 @@ class BasicMap extends PureComponent {
     }
 
     if (onFeaturesClick) {
-      this.singleClickRef = this.map.on('singleclick', (evt) => {
-        const features = evt.map.getFeaturesAtPixel(
-          evt.pixel,
-          featuresClickOptions,
-        );
-        onFeaturesClick(features || [], evt);
-      });
+      this.listenSingleClick();
     }
 
     if (onFeaturesHover) {
-      this.pointerMoveRef = this.map.on('pointermove', (evt) => {
-        const features = evt.map.getFeaturesAtPixel(evt.pixel);
-        onFeaturesHover(features || [], evt);
-      });
+      this.listenPointerMove();
     }
   }
 
@@ -235,6 +225,8 @@ class BasicMap extends PureComponent {
       resolution,
       viewOptions,
       zoom,
+      onFeaturesClick,
+      onFeaturesHover,
     } = this.props;
     const { node } = this.state;
 
@@ -287,6 +279,14 @@ class BasicMap extends PureComponent {
 
     if (extent && !equals(extent, prevProps.extent || [])) {
       view.fit(extent, fitOptions);
+    }
+
+    if (onFeaturesClick !== prevProps.onFeaturesClick) {
+      this.listenSingleClick();
+    }
+
+    if (onFeaturesHover !== prevProps.onFeaturesHover) {
+      this.listenPointerMove();
     }
   }
 
@@ -341,6 +341,37 @@ class BasicMap extends PureComponent {
     for (let i = 0; i < layers.length; i += 1) {
       this.terminateLayer(layers[i]);
     }
+  }
+
+  listenSingleClick() {
+    const { onFeaturesClick, featuresClickOptions } = this.props;
+    unByKey(this.singleClickRef);
+
+    if (!onFeaturesClick) {
+      return;
+    }
+
+    this.singleClickRef = this.map.on('singleclick', (evt) => {
+      const features = evt.map.getFeaturesAtPixel(
+        evt.pixel,
+        featuresClickOptions,
+      );
+      onFeaturesClick(features || [], evt);
+    });
+  }
+
+  listenPointerMove() {
+    const { onFeaturesHover } = this.props;
+    unByKey(this.pointerMoveRef);
+
+    if (!onFeaturesHover) {
+      return;
+    }
+
+    this.pointerMoveRef = this.map.on('pointermove', (evt) => {
+      const features = evt.map.getFeaturesAtPixel(evt.pixel);
+      onFeaturesHover(features || [], evt);
+    });
   }
 
   render() {

--- a/src/components/BasicMap/BasicMap.js
+++ b/src/components/BasicMap/BasicMap.js
@@ -169,9 +169,6 @@ class BasicMap extends PureComponent {
 
   componentDidMount() {
     const {
-      onMapMoved,
-      onFeaturesClick,
-      onFeaturesHover,
       layers,
       extent,
       viewOptions,
@@ -198,21 +195,10 @@ class BasicMap extends PureComponent {
       this.map.getView().fit(extent);
     }
 
-    if (layers.length) {
-      this.setLayers(layers);
-    }
-
-    if (onMapMoved) {
-      this.mapMoveRef = this.map.on('moveend', (evt) => onMapMoved(evt));
-    }
-
-    if (onFeaturesClick) {
-      this.listenSingleClick();
-    }
-
-    if (onFeaturesHover) {
-      this.listenPointerMove();
-    }
+    this.setLayers(layers);
+    this.listenMoveEnd();
+    this.listenSingleClick();
+    this.listenPointerMove();
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -225,6 +211,7 @@ class BasicMap extends PureComponent {
       resolution,
       viewOptions,
       zoom,
+      onMapMoved,
       onFeaturesClick,
       onFeaturesHover,
     } = this.props;
@@ -279,6 +266,10 @@ class BasicMap extends PureComponent {
 
     if (extent && !equals(extent, prevProps.extent || [])) {
       view.fit(extent, fitOptions);
+    }
+
+    if (onMapMoved !== prevProps.onMapMoved) {
+      this.listenMoveEnd();
     }
 
     if (onFeaturesClick !== prevProps.onFeaturesClick) {
@@ -341,6 +332,17 @@ class BasicMap extends PureComponent {
     for (let i = 0; i < layers.length; i += 1) {
       this.terminateLayer(layers[i]);
     }
+  }
+
+  listenMoveEnd() {
+    const { onMapMoved } = this.props;
+    unByKey(this.moveEndRef);
+
+    if (!onMapMoved) {
+      return;
+    }
+
+    this.moveEndRef = this.map.on('moveend', (evt) => onMapMoved(evt));
   }
 
   listenSingleClick() {

--- a/src/components/BasicMap/BasicMap.js
+++ b/src/components/BasicMap/BasicMap.js
@@ -161,9 +161,10 @@ class BasicMap extends PureComponent {
       node: null,
     };
 
+    this.layers = [];
+    this.moveEndRef = null;
     this.singleClickRef = null;
     this.pointerMoveRef = null;
-    this.layers = [];
     this.setNode = this.setNode.bind(this);
   }
 

--- a/src/components/BasicMap/BasicMap.test.js
+++ b/src/components/BasicMap/BasicMap.test.js
@@ -61,20 +61,64 @@ describe('BasicMap', () => {
 
   test('uses onFeaturesClick function', () => {
     const spy = jest.fn();
-    shallow(<BasicMap map={olMap} onFeaturesClick={spy} />);
+    const spy2 = jest.fn();
     const evt = new MapEvent('singleclick', olMap);
+
+    // Test componnetDidMount
+    const wrapper = shallow(<BasicMap map={olMap} onFeaturesClick={spy} />, {
+      lifecycleExperimental: true,
+    });
     olMap.dispatchEvent(evt);
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith([], evt);
+
+    // Test componentDidUpdate
+    wrapper.setProps({
+      onFeaturesClick: spy2,
+    });
+    olMap.dispatchEvent(evt);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy2).toHaveBeenCalledTimes(1);
+    expect(spy2).toHaveBeenCalledWith([], evt);
+
+    // Test componentDidUpdate
+    wrapper.setProps({
+      onFeaturesClick: null,
+    });
+    olMap.dispatchEvent(evt);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy2).toHaveBeenCalledTimes(1);
   });
 
   test('uses onFeaturesHover function', () => {
     const spy = jest.fn();
-    shallow(<BasicMap map={olMap} onFeaturesHover={spy} />);
+    const spy2 = jest.fn();
     const evt = new MapEvent('pointermove', olMap);
+
+    // Test componnetDidMount
+    const wrapper = shallow(<BasicMap map={olMap} onFeaturesHover={spy} />, {
+      lifecycleExperimental: true,
+    });
     olMap.dispatchEvent(evt);
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith([], evt);
+
+    // Test componentDidUpdate
+    wrapper.setProps({
+      onFeaturesHover: spy2,
+    });
+    olMap.dispatchEvent(evt);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy2).toHaveBeenCalledTimes(1);
+    expect(spy2).toHaveBeenCalledWith([], evt);
+
+    // Test componentDidUpdate
+    wrapper.setProps({
+      onFeaturesHover: null,
+    });
+    olMap.dispatchEvent(evt);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy2).toHaveBeenCalledTimes(1);
   });
 
   test('should be rendered with a default map', () => {

--- a/src/components/BasicMap/BasicMap.test.js
+++ b/src/components/BasicMap/BasicMap.test.js
@@ -54,9 +54,31 @@ describe('BasicMap', () => {
 
   test('uses onMapMoved function', () => {
     const spy = jest.fn(() => {});
-    shallow(<BasicMap map={olMap} onMapMoved={spy} />);
-    olMap.dispatchEvent(new MapEvent('moveend', olMap));
+    const spy2 = jest.fn();
+    const evt = new MapEvent('moveend', olMap);
+
+    // Test componentDidMount
+    const wrapper = shallow(<BasicMap map={olMap} onMapMoved={spy} />);
+    olMap.dispatchEvent(evt);
     expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(evt);
+
+    // Test componentDidUpdate
+    wrapper.setProps({
+      onMapMoved: spy2,
+    });
+    olMap.dispatchEvent(evt);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy2).toHaveBeenCalledTimes(1);
+    expect(spy2).toHaveBeenCalledWith(evt);
+
+    // Test componentDidUpdate
+    wrapper.setProps({
+      onMapMoved: null,
+    });
+    olMap.dispatchEvent(evt);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy2).toHaveBeenCalledTimes(1);
   });
 
   test('uses onFeaturesClick function', () => {
@@ -64,7 +86,7 @@ describe('BasicMap', () => {
     const spy2 = jest.fn();
     const evt = new MapEvent('singleclick', olMap);
 
-    // Test componnetDidMount
+    // Test componentDidMount
     const wrapper = shallow(<BasicMap map={olMap} onFeaturesClick={spy} />, {
       lifecycleExperimental: true,
     });
@@ -95,7 +117,7 @@ describe('BasicMap', () => {
     const spy2 = jest.fn();
     const evt = new MapEvent('pointermove', olMap);
 
-    // Test componnetDidMount
+    // Test componentDidMount
     const wrapper = shallow(<BasicMap map={olMap} onFeaturesHover={spy} />, {
       lifecycleExperimental: true,
     });

--- a/src/utils/KML.js
+++ b/src/utils/KML.js
@@ -121,7 +121,12 @@ const sanitizeFeature = (feature) => {
         fill: style.getText().getFill(),
         // rotation unsupported by KML, taken instead from custom field.
         rotation: feature.get('textRotation') || 0,
-        stroke: style.getText().getStroke(),
+        // since ol 6.3.1 : https://github.com/openlayers/openlayers/pull/10613/files#diff-1883da8b57e690db7ea0c35ce53c880aR925
+        // a default textstroke is added to mimic google earth.
+        // it was not the case before, the stroke was always null. So to keep
+        // the same behavior we don't copy the stroke style.
+        // TODO : maybe we should use this functionnality in the futur.
+        // stroke: style.getText().getStroke(),
         scale: style.getText().getScale(),
       });
 

--- a/src/utils/KML.test.js
+++ b/src/utils/KML.test.js
@@ -148,6 +148,7 @@ describe('KML', () => {
       expect(style.getText()).toBe('bar'); // spaces are trimmed.
       expect(style.getFont()).toEqual('bold 16px arial');
       expect(style.getFill()).toEqual({ color_: [32, 52, 126, 1] });
+      expect(style.getStroke()).toEqual(null);
       expect(style.getScale()).toEqual(2);
       expect(style.getRotation()).toEqual('2.303834612632515');
       expect(style.getPadding()).toEqual([5, 6, 7, 8]);


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->

The update of  the properties onFeaturesHover, onFeaturesClick on MapMoved were ignored.
This PR fixes this.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
