### PR TITLE
switcher now toggles on two layers only instead of opening

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "1.0.1",
+  "version": "1.0.3-beta.1",
   "license": "MIT",
   "dependencies": {
     "abortcontroller-polyfill": "1.5.0",

--- a/src/components/BaseLayerSwitcher/BaseLayerSwitcher.js
+++ b/src/components/BaseLayerSwitcher/BaseLayerSwitcher.js
@@ -109,6 +109,18 @@ function BaseLayerSwitcher({
   const openClass = switcherOpen ? ' rs-open' : '';
   const hiddenStyle = switcherOpen && !isClosed ? 'visible' : 'hidden';
 
+  const handleSwitcherClick = () => {
+    if (baseLayers.length === 2) {
+      /* On only two layer options the opener becomes a layer toggle button */
+      const nextLayer = baseLayers.find((layer) => !layer.visible);
+      setCurrentLayer(nextLayer);
+      nextLayer.setVisible(true);
+      return;
+    }
+    setSwitcherOpen(true);
+    setIsClosed(false);
+  };
+
   const onLayerSelect = (layer) => {
     if (!switcherOpen) {
       setSwitcherOpen(true);
@@ -172,10 +184,12 @@ function BaseLayerSwitcher({
           role="button"
           title={titles.openSwitcher}
           aria-label={titles.openSwitcher}
-          onClick={() => setSwitcherOpen(true) && setIsClosed(false)}
-          onKeyPress={(e) =>
-            e.which === 13 && setSwitcherOpen(true) && setIsClosed(false)
-          }
+          onClick={handleSwitcherClick}
+          onKeyPress={(e) => {
+            if (e.which === 13) {
+              handleSwitcherClick();
+            }
+          }}
           style={getImageStyle(nextImage)}
           tabIndex="0"
         >

--- a/src/components/BaseLayerSwitcher/BaseLayerSwitcher.test.js
+++ b/src/components/BaseLayerSwitcher/BaseLayerSwitcher.test.js
@@ -40,17 +40,25 @@ describe('BaseLayerSwitcher', () => {
   });
 
   test('the correct baselayer is visible on mount', () => {
-    const comp = mountComp(data);
+    const comp = mountComp();
     expect(comp.props().layers[0].visible).toBe(true);
   });
 
   test('removes open class and switches layer on click', () => {
-    const comp = mountComp(data);
+    const comp = mountComp();
     comp.find('.rs-opener').at(0).simulate('click');
     comp.find('.rs-base-layer-switcher-button').at(3).simulate('click');
     expect(
       comp.props().layers.filter((layer) => layer.isBaseLayer)[2].visible,
     ).toBe(true);
     expect(comp.find('.rs-base-layer-switcher rs-open').exists()).toBe(false);
+  });
+
+  test.only('toggles base map instead of opening when only two base layers', () => {
+    const comp = mountComp(data.slice(0, 2));
+    comp.find('.rs-opener').at(0).simulate('click');
+    expect(
+      comp.props().layers.filter((layer) => layer.isBaseLayer)[1].visible,
+    ).toBe(true);
   });
 });

--- a/src/components/BaseLayerSwitcher/BaseLayerSwitcher.test.js
+++ b/src/components/BaseLayerSwitcher/BaseLayerSwitcher.test.js
@@ -60,5 +60,6 @@ describe('BaseLayerSwitcher', () => {
     expect(
       comp.props().layers.filter((layer) => layer.isBaseLayer)[1].visible,
     ).toBe(true);
+    expect(comp.find('.rs-base-layer-switcher rs-open').exists()).toBe(false);
   });
 });


### PR DESCRIPTION
# How to

When only two base layer options are available in the Switcher, the Switcher should toggle between the two layers on click instead of opening.

Test:
- Load the review app styleguide
- In the example for the BaseLayerSwitcher, in the BaseLayerSwitcher props change layers={layers} to layers={layers.slice(1)} (remove one base layer to a total of two)
- Click on the BaseLayerSwitcher
- The Switcher should toggle the base map instead of opening the Switcher 

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [ ] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
