### PR TITLE
BLS Switcher title update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "1.0.4-beta.1",
+  "version": "1.0.4-beta.2",
   "license": "MIT",
   "dependencies": {
     "abortcontroller-polyfill": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "1.0.3",
+  "version": "1.0.4-beta.1",
   "license": "MIT",
   "dependencies": {
     "abortcontroller-polyfill": "1.5.0",

--- a/src/components/BaseLayerSwitcher/BaseLayerSwitcher.js
+++ b/src/components/BaseLayerSwitcher/BaseLayerSwitcher.js
@@ -193,7 +193,12 @@ function BaseLayerSwitcher({
           style={getImageStyle(nextImage)}
           tabIndex="0"
         >
-          <div className="rs-base-layer-switcher-title">{titles.button}</div>
+          <div className="rs-base-layer-switcher-title">
+            {baseLayers.length !== 2
+              ? titles.button
+              : baseLayers.find((layer) => !layer.visible) &&
+                baseLayers.find((layer) => !layer.visible).name}
+          </div>
           {nextImage ? null : <span className="rs-alt-text">{t(altText)}</span>}
         </div>
       }

--- a/src/components/BaseLayerSwitcher/BaseLayerSwitcher.js
+++ b/src/components/BaseLayerSwitcher/BaseLayerSwitcher.js
@@ -197,7 +197,7 @@ function BaseLayerSwitcher({
             {baseLayers.length !== 2
               ? titles.button
               : baseLayers.find((layer) => !layer.visible) &&
-                baseLayers.find((layer) => !layer.visible).name}
+                t(baseLayers.find((layer) => !layer.visible).name)}
           </div>
           {nextImage ? null : <span className="rs-alt-text">{t(altText)}</span>}
         </div>

--- a/src/components/BaseLayerSwitcher/BaseLayerSwitcher.test.js
+++ b/src/components/BaseLayerSwitcher/BaseLayerSwitcher.test.js
@@ -56,6 +56,9 @@ describe('BaseLayerSwitcher', () => {
 
   test.only('toggles base map instead of opening when only two base layers', () => {
     const comp = mountComp(data.slice(0, 2));
+    expect(
+      comp.props().layers.filter((layer) => layer.isBaseLayer)[0].visible,
+    ).toBe(true);
     comp.find('.rs-opener').at(0).simulate('click');
     expect(
       comp.props().layers.filter((layer) => layer.isBaseLayer)[1].visible,


### PR DESCRIPTION
# How to

When only two base maps are present, the layer name is shown on the switcher opener directly (otherwise it shows a configurable title like "Switch Baselayer")

Test:

- Load the review app styleguide
- In the example for the BaseLayerSwitcher, in the BaseLayerSwitcher props change layers={layers} to layers={layers.slice(1)} (remove one base layer to a total of two)
- Click on the BaseLayerSwitcher
- The Switcher should toggle the base map instead of opening the Switcher
- Switcher title should be Layer names

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
