### PR TITLE
KML icon rotation

### DIFF
--- a/src/utils/KML.js
+++ b/src/utils/KML.js
@@ -164,6 +164,11 @@ const sanitizeFeature = (feature) => {
       }
     }
 
+    if (image instanceof Icon) {
+      // Apply icon rotation if defined
+      image.setRotation(parseFloat(feature.get('iconRotation')) || 0);
+    }
+
     fill = undefined;
     stroke = undefined;
 
@@ -346,6 +351,11 @@ const writeFeatures = (layer, featureProjection) => {
           "Local image source isn't support for KML export." +
             'Should use remote web server',
         );
+      }
+
+      if (newStyle.image.getRotation()) {
+        // We set the icon rotation as extended data
+        clone.set('iconRotation', newStyle.image.getRotation());
       }
     }
 

--- a/src/utils/KML.js
+++ b/src/utils/KML.js
@@ -165,7 +165,9 @@ const sanitizeFeature = (feature) => {
     }
 
     if (image instanceof Icon) {
-      // Apply icon rotation if defined
+      /* Apply icon rotation if defined (by default only written as
+       * <heading> tag, which is not read as rotation value by the ol KML module)
+       */
       image.setRotation(parseFloat(feature.get('iconRotation')) || 0);
     }
 

--- a/src/utils/KML.test.js
+++ b/src/utils/KML.test.js
@@ -213,7 +213,7 @@ describe('KML', () => {
       expectWriteResult(feats, str);
     });
 
-    test('should add zIndex to the feature style.', () => {
+    test('should add zIndex and rotation to icon style.', () => {
       const str = `
       <kml ${xmlns}>
         <Document>
@@ -223,6 +223,9 @@ describe('KML', () => {
                 <Style>
                     <IconStyle>
                         <scale>0.5</scale>
+                        <heading>
+                          1.5707963267948966
+                        </heading>
                         <Icon>
                             <href>https://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
                             <gx:w>64</gx:w>
@@ -232,6 +235,9 @@ describe('KML', () => {
                     </IconStyle>
                 </Style>
                 <ExtendedData>
+                    <Data name="iconRotation">
+                      <value>1.5707963267948966</value>
+                    </Data>
                     <Data name="zIndex">
                         <value>1</value>
                     </Data>
@@ -246,6 +252,7 @@ describe('KML', () => {
       const feats = KML.readFeatures(str);
       const style = feats[0].getStyle()[0];
       expect(style.getZIndex()).toBe(1);
+      expect(style.getImage().getRotation()).toBe(1.5707963267948966);
       expectWriteResult(feats, str);
     });
   });


### PR DESCRIPTION
# How to

In mapset, it should be possible to rotate icons with the feature styler.
Currently this does not work, since the "rotation" value in icon styles is written as a <heading> tag into the kml string,
which in turn is not read by the KML module and the value isn't added to any feature property by default. 

Solution: We write the value into the kml extended data and read it from there when loading rotated icons 

# Others

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [] IE11 tested.
- [] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
