### PR TITLE
Parameter for dynamic icon scaling

### DIFF
--- a/src/components/BaseLayerSwitcher/BaseLayerSwitcher.test.js
+++ b/src/components/BaseLayerSwitcher/BaseLayerSwitcher.test.js
@@ -54,7 +54,7 @@ describe('BaseLayerSwitcher', () => {
     expect(comp.find('.rs-base-layer-switcher rs-open').exists()).toBe(false);
   });
 
-  test.only('toggles base map instead of opening when only two base layers', () => {
+  test('toggles base map instead of opening when only two base layers', () => {
     const comp = mountComp(data.slice(0, 2));
     expect(
       comp.props().layers.filter((layer) => layer.isBaseLayer)[0].visible,

--- a/src/utils/KML.js
+++ b/src/utils/KML.js
@@ -169,6 +169,16 @@ const sanitizeFeature = (feature) => {
        * <heading> tag, which is not read as rotation value by the ol KML module)
        */
       image.setRotation(parseFloat(feature.get('iconRotation')) || 0);
+
+      /* Value to be used for icon scaling with map
+       * e.g. icon.setScale(map.getView().getResolutionForZoom(zoomAtMaxIconSize) / map.getView().getResolution())
+       */
+      if (feature.get('zoomAtMaxIconSize')) {
+        feature.set(
+          'zoomAtMaxIconSize',
+          parseFloat(feature.get('zoomAtMaxIconSize')),
+        );
+      }
     }
 
     fill = undefined;
@@ -358,6 +368,12 @@ const writeFeatures = (layer, featureProjection) => {
       if (newStyle.image.getRotation()) {
         // We set the icon rotation as extended data
         clone.set('iconRotation', newStyle.image.getRotation());
+      }
+
+      // Set zoomAtMaxIconSize to use for icon-to-map proportional scaling
+      if (f.get('zoomAtMaxIconSize')) {
+        clone.set('zoomAtMaxIconSize', f.get('zoomAtMaxIconSize'));
+        newStyle.fill = null;
       }
     }
 

--- a/src/utils/KML.test.js
+++ b/src/utils/KML.test.js
@@ -213,7 +213,7 @@ describe('KML', () => {
       expectWriteResult(feats, str);
     });
 
-    test('should add zIndex and rotation to icon style.', () => {
+    test('should add zIndex and rotation to icon style and zoomAtMaxIconSize to feature properties.', () => {
       const str = `
       <kml ${xmlns}>
         <Document>
@@ -241,6 +241,9 @@ describe('KML', () => {
                     <Data name="zIndex">
                         <value>1</value>
                     </Data>
+                    <Data name="zoomAtMaxIconSize">
+                      <value>12.65397</value>
+                    </Data>
                 </ExtendedData>
                 <Point>
                     <coordinates>0,0,0</coordinates>
@@ -253,6 +256,7 @@ describe('KML', () => {
       const style = feats[0].getStyle()[0];
       expect(style.getZIndex()).toBe(1);
       expect(style.getImage().getRotation()).toBe(1.5707963267948966);
+      expect(feats[0].get('zoomAtMaxIconSize')).toBe(12.65397);
       expectWriteResult(feats, str);
     });
   });


### PR DESCRIPTION
# How to

Added extended data option _zoomAtMaxIconSize_ in KML reader/writer. Used for scaling icons proportionally to the map:
e.g.:
`icon.setScale(map.getView().getResolutionForZoom(zoomAtMaxIconSize) / map.getView().getResolution())` 

Tested locally in mapset Plan-Editor.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [ ] IE11 tested.
- [ ] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
