### PR TITLE
Add custom render function for the LayerTree item

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "1.0.7",
+  "version": "1.0.8-beta.1",
   "license": "MIT",
   "dependencies": {
     "@geops/geops-ui": "0.1.4",

--- a/src/components/LayerTree/LayerTree.js
+++ b/src/components/LayerTree/LayerTree.js
@@ -50,6 +50,24 @@ const propTypes = {
   renderItemContent: PropTypes.func,
 
   /**
+   * Custom function to render custom content before the list of children of an item.
+   *
+   * @param {object} item The item to render.
+   *
+   * @return {node} A jsx node.
+   */
+  renderBeforeItem: PropTypes.func,
+
+  /**
+   * Custom function to render custom content after the list of children of an item.
+   *
+   * @param {object} item The item to render.
+   *
+   * @return {node} A jsx node.
+   */
+  renderAfterItem: PropTypes.func,
+
+  /**
    * Object holding title for the layer tree's buttons.
    */
   titles: PropTypes.shape({
@@ -86,6 +104,8 @@ const defaultProps = {
   getParentClassName: () => undefined,
   renderItem: null,
   renderItemContent: null,
+  renderBeforeItem: null,
+  renderAfterItem: null,
   titles: {
     layerShow: 'Show layer',
     layerHide: 'Hide layer',
@@ -295,6 +315,8 @@ class LayerTree extends Component {
     const {
       renderItem,
       renderItemContent,
+      renderBeforeItem,
+      renderAfterItem,
       padding,
       getParentClassName,
     } = this.props;
@@ -320,9 +342,11 @@ class LayerTree extends Component {
             ? renderItemContent(layer, this)
             : this.renderItemContent(layer)}
         </div>
+        {renderBeforeItem && renderBeforeItem(layer, level, this)}
         {[...children]
           .reverse()
           .map((child) => this.renderItem(child, level + 1))}
+        {renderAfterItem && renderAfterItem(layer, level, this)}
       </div>
     );
   }

--- a/src/components/LayerTree/LayerTree.test.js
+++ b/src/components/LayerTree/LayerTree.test.js
@@ -69,16 +69,20 @@ describe('LayerTree', () => {
 
     test('when an item use renderBeforeItem.', () => {
       renderLayerTree(data, {
-        renderBeforeItem: (layer) => (
-          <div>Render name before item: {layer.name}</div>
+        renderBeforeItem: (layer, level) => (
+          <div>
+            Render name before item: {layer.name}, level: {level}
+          </div>
         ),
       });
     });
 
     test('when an item use renderAfterItem.', () => {
       renderLayerTree(data, {
-        renderAfterItem: (layer) => (
-          <div>Render name after item: {layer.name}</div>
+        renderAfterItem: (layer, level) => (
+          <div>
+            Render name after item: {layer.name}, level: {level}
+          </div>
         ),
       });
     });

--- a/src/components/LayerTree/LayerTree.test.js
+++ b/src/components/LayerTree/LayerTree.test.js
@@ -67,6 +67,22 @@ describe('LayerTree', () => {
       });
     });
 
+    test('when an item use renderBeforeItem.', () => {
+      renderLayerTree(data, {
+        renderAfterItem: (layer) => (
+          <div>Render name before item: {layer.name}</div>
+        ),
+      });
+    });
+
+    test('when an item use renderAfterItem.', () => {
+      renderLayerTree(data, {
+        renderAfterItem: (layer) => (
+          <div>Render name after item: {layer.name}</div>
+        ),
+      });
+    });
+
     test('when items are always expanded', () => {
       const dataExp = [
         {

--- a/src/components/LayerTree/LayerTree.test.js
+++ b/src/components/LayerTree/LayerTree.test.js
@@ -69,7 +69,7 @@ describe('LayerTree', () => {
 
     test('when an item use renderBeforeItem.', () => {
       renderLayerTree(data, {
-        renderAfterItem: (layer) => (
+        renderBeforeItem: (layer) => (
           <div>Render name before item: {layer.name}</div>
         ),
       });

--- a/src/components/LayerTree/__snapshots__/LayerTree.test.js.snap
+++ b/src/components/LayerTree/__snapshots__/LayerTree.test.js.snap
@@ -1842,6 +1842,10 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
       </div>
     </div>
     <div>
+      Render name before item: 
+      Road sample layers
+    </div>
+    <div>
       <div
         className="rs-layer-tree-item rs-visible"
         style={
@@ -1931,10 +1935,6 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
         Roads Seoul
       </div>
     </div>
-    <div>
-      Render name before item: 
-      Road sample layers
-    </div>
   </div>
   <div>
     <div
@@ -1978,6 +1978,10 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
           className="rs-layer-tree-arrow rs-layer-tree-arrow-expanded"
         />
       </div>
+    </div>
+    <div>
+      Render name before item: 
+      Vector sample layers
     </div>
     <div>
       <div
@@ -2114,10 +2118,6 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
         Polygons Samples
       </div>
     </div>
-    <div>
-      Render name before item: 
-      Vector sample layers
-    </div>
   </div>
   <div>
     <div
@@ -2163,6 +2163,10 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
       </div>
     </div>
     <div>
+      Render name before item: 
+      Other layers
+    </div>
+    <div>
       <div
         className="rs-layer-tree-item "
         style={
@@ -2201,6 +2205,10 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
             Countries
           </div>
         </div>
+      </div>
+      <div>
+        Render name before item: 
+        Countries
       </div>
       <div>
         <div
@@ -2292,10 +2300,6 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
           Countries 110m
         </div>
       </div>
-      <div>
-        Render name before item: 
-        Countries
-      </div>
     </div>
     <div>
       <div
@@ -2386,10 +2390,6 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
         Render name before item: 
         Switzerland
       </div>
-    </div>
-    <div>
-      Render name before item: 
-      Other layers
     </div>
   </div>
   <div>

--- a/src/components/LayerTree/__snapshots__/LayerTree.test.js.snap
+++ b/src/components/LayerTree/__snapshots__/LayerTree.test.js.snap
@@ -1058,6 +1058,1478 @@ exports[`LayerTree matches snapshots when an item is hidden. 1`] = `
 </div>
 `;
 
+exports[`LayerTree matches snapshots when an item use renderAfterItem. 1`] = `
+<div
+  className="rs-layer-tree"
+>
+  <div>
+    <div
+      className="rs-layer-tree-item rs-visible"
+      style={
+        Object {
+          "paddingLeft": "0px",
+        }
+      }
+    >
+      <label
+        aria-label="Hide layer"
+        className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+        onKeyPress={[Function]}
+        tabIndex={0}
+        title="Hide layer"
+      >
+        <input
+          checked={true}
+          onClick={[Function]}
+          readOnly={true}
+          tabIndex={-1}
+          type="checkbox"
+        />
+        <span />
+      </label>
+      <div
+        aria-expanded={true}
+        aria-label="Road sample layers Hide sublayer"
+        className="rs-layer-tree-toggle"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        tabIndex={0}
+        title="Road sample layers Hide sublayer"
+      >
+        <div>
+          Road sample layers
+        </div>
+        <div
+          className="rs-layer-tree-arrow rs-layer-tree-arrow-expanded"
+        />
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item rs-visible"
+        style={
+          Object {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <label
+          aria-label="Hide layer"
+          className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+          onKeyPress={[Function]}
+          tabIndex={-1}
+          title="Hide layer"
+        >
+          <input
+            checked={true}
+            onClick={[Function]}
+            readOnly={true}
+            tabIndex={-1}
+            type="checkbox"
+          />
+          <span />
+        </label>
+        <div
+          aria-expanded={false}
+          aria-label="Vienna Streets Show sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="Vienna Streets Show sublayer"
+        >
+          <div>
+            Vienna Streets
+          </div>
+        </div>
+      </div>
+      <div>
+        Render name after item: 
+        Vienna Streets
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item rs-visible"
+        style={
+          Object {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <label
+          aria-label="Hide layer"
+          className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+          onKeyPress={[Function]}
+          tabIndex={-1}
+          title="Hide layer"
+        >
+          <input
+            checked={true}
+            onClick={[Function]}
+            readOnly={true}
+            tabIndex={-1}
+            type="checkbox"
+          />
+          <span />
+        </label>
+        <div
+          aria-expanded={false}
+          aria-label="Roads Seoul Show sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="Roads Seoul Show sublayer"
+        >
+          <div>
+            Roads Seoul
+          </div>
+        </div>
+      </div>
+      <div>
+        Render name after item: 
+        Roads Seoul
+      </div>
+    </div>
+    <div>
+      Render name after item: 
+      Road sample layers
+    </div>
+  </div>
+  <div>
+    <div
+      className="rs-layer-tree-item rs-visible"
+      style={
+        Object {
+          "paddingLeft": "0px",
+        }
+      }
+    >
+      <label
+        aria-label="Hide layer"
+        className="rs-layer-tree-input rs-layer-tree-input-radio rs-radio"
+        onKeyPress={[Function]}
+        tabIndex={0}
+        title="Hide layer"
+      >
+        <input
+          checked={true}
+          onClick={[Function]}
+          readOnly={true}
+          tabIndex={-1}
+          type="radio"
+        />
+        <span />
+      </label>
+      <div
+        aria-expanded={true}
+        aria-label="Vector sample layers Hide sublayer"
+        className="rs-layer-tree-toggle"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        tabIndex={0}
+        title="Vector sample layers Hide sublayer"
+      >
+        <div>
+          Vector sample layers
+        </div>
+        <div
+          className="rs-layer-tree-arrow rs-layer-tree-arrow-expanded"
+        />
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item "
+        style={
+          Object {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <label
+          aria-label="Show layer"
+          className="rs-layer-tree-input rs-layer-tree-input-radio rs-radio"
+          onKeyPress={[Function]}
+          tabIndex={-1}
+          title="Show layer"
+        >
+          <input
+            checked={false}
+            onClick={[Function]}
+            readOnly={true}
+            tabIndex={-1}
+            type="radio"
+          />
+          <span />
+        </label>
+        <div
+          aria-expanded={false}
+          aria-label="Points Samples Show sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="Points Samples Show sublayer"
+        >
+          <div>
+            Points Samples
+          </div>
+        </div>
+      </div>
+      <div>
+        Render name after item: 
+        Points Samples
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item rs-visible"
+        style={
+          Object {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <label
+          aria-label="Hide layer"
+          className="rs-layer-tree-input rs-layer-tree-input-radio rs-radio"
+          onKeyPress={[Function]}
+          tabIndex={-1}
+          title="Hide layer"
+        >
+          <input
+            checked={true}
+            onClick={[Function]}
+            readOnly={true}
+            tabIndex={-1}
+            type="radio"
+          />
+          <span />
+        </label>
+        <div
+          aria-expanded={false}
+          aria-label="Lines Samples Show sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="Lines Samples Show sublayer"
+        >
+          <div>
+            Lines Samples
+          </div>
+        </div>
+      </div>
+      <div>
+        Render name after item: 
+        Lines Samples
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item "
+        style={
+          Object {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <label
+          aria-label="Show layer"
+          className="rs-layer-tree-input rs-layer-tree-input-radio rs-radio"
+          onKeyPress={[Function]}
+          tabIndex={-1}
+          title="Show layer"
+        >
+          <input
+            checked={false}
+            onClick={[Function]}
+            readOnly={true}
+            tabIndex={-1}
+            type="radio"
+          />
+          <span />
+        </label>
+        <div
+          aria-expanded={false}
+          aria-label="Polygons Samples Show sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="Polygons Samples Show sublayer"
+        >
+          <div>
+            Polygons Samples
+          </div>
+        </div>
+      </div>
+      <div>
+        Render name after item: 
+        Polygons Samples
+      </div>
+    </div>
+    <div>
+      Render name after item: 
+      Vector sample layers
+    </div>
+  </div>
+  <div>
+    <div
+      className="rs-layer-tree-item rs-visible"
+      style={
+        Object {
+          "paddingLeft": "0px",
+        }
+      }
+    >
+      <label
+        aria-label="Hide layer"
+        className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+        onKeyPress={[Function]}
+        tabIndex={0}
+        title="Hide layer"
+      >
+        <input
+          checked={true}
+          onClick={[Function]}
+          readOnly={true}
+          tabIndex={-1}
+          type="checkbox"
+        />
+        <span />
+      </label>
+      <div
+        aria-expanded={true}
+        aria-label="Other layers Hide sublayer"
+        className="rs-layer-tree-toggle"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        tabIndex={0}
+        title="Other layers Hide sublayer"
+      >
+        <div>
+          Other layers
+        </div>
+        <div
+          className="rs-layer-tree-arrow rs-layer-tree-arrow-expanded"
+        />
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item "
+        style={
+          Object {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <label
+          aria-label="Show layer"
+          className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+          onKeyPress={[Function]}
+          tabIndex={0}
+          title="Show layer"
+        >
+          <input
+            checked={false}
+            onClick={[Function]}
+            readOnly={true}
+            tabIndex={-1}
+            type="checkbox"
+          />
+          <span />
+        </label>
+        <div
+          aria-expanded={true}
+          aria-label="Countries Hide sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="Countries Hide sublayer"
+        >
+          <div>
+            Countries
+          </div>
+        </div>
+      </div>
+      <div>
+        <div
+          className="rs-layer-tree-item "
+          style={
+            Object {
+              "paddingLeft": "60px",
+            }
+          }
+        >
+          <label
+            aria-label="Show layer"
+            className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+            onKeyPress={[Function]}
+            tabIndex={-1}
+            title="Show layer"
+          >
+            <input
+              checked={false}
+              onClick={[Function]}
+              readOnly={true}
+              tabIndex={-1}
+              type="checkbox"
+            />
+            <span />
+          </label>
+          <div
+            aria-expanded={false}
+            aria-label="Countries Borders Show sublayer"
+            className="rs-layer-tree-toggle"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+            title="Countries Borders Show sublayer"
+          >
+            <div>
+              Countries Borders
+            </div>
+          </div>
+        </div>
+        <div>
+          Render name after item: 
+          Countries Borders
+        </div>
+      </div>
+      <div>
+        <div
+          className="rs-layer-tree-item "
+          style={
+            Object {
+              "paddingLeft": "60px",
+            }
+          }
+        >
+          <label
+            aria-label="Show layer"
+            className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+            onKeyPress={[Function]}
+            tabIndex={-1}
+            title="Show layer"
+          >
+            <input
+              checked={false}
+              onClick={[Function]}
+              readOnly={true}
+              tabIndex={-1}
+              type="checkbox"
+            />
+            <span />
+          </label>
+          <div
+            aria-expanded={false}
+            aria-label="Countries 110m Show sublayer"
+            className="rs-layer-tree-toggle"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+            title="Countries 110m Show sublayer"
+          >
+            <div>
+              Countries 110m
+            </div>
+          </div>
+        </div>
+        <div>
+          Render name after item: 
+          Countries 110m
+        </div>
+      </div>
+      <div>
+        Render name after item: 
+        Countries
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item rs-visible"
+        style={
+          Object {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <label
+          aria-label="Hide layer"
+          className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+          onKeyPress={[Function]}
+          tabIndex={-1}
+          title="Hide layer"
+        >
+          <input
+            checked={true}
+            onClick={[Function]}
+            readOnly={true}
+            tabIndex={-1}
+            type="checkbox"
+          />
+          <span />
+        </label>
+        <div
+          aria-expanded={false}
+          aria-label="USA Population Density Show sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="USA Population Density Show sublayer"
+        >
+          <div>
+            USA Population Density
+          </div>
+        </div>
+      </div>
+      <div>
+        Render name after item: 
+        USA Population Density
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item rs-visible"
+        style={
+          Object {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <label
+          aria-label="Hide layer"
+          className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+          onKeyPress={[Function]}
+          tabIndex={-1}
+          title="Hide layer"
+        >
+          <input
+            checked={true}
+            onClick={[Function]}
+            readOnly={true}
+            tabIndex={-1}
+            type="checkbox"
+          />
+          <span />
+        </label>
+        <div
+          aria-expanded={false}
+          aria-label="Switzerland Show sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="Switzerland Show sublayer"
+        >
+          <div>
+            Switzerland
+          </div>
+        </div>
+      </div>
+      <div>
+        Render name after item: 
+        Switzerland
+      </div>
+    </div>
+    <div>
+      Render name after item: 
+      Other layers
+    </div>
+  </div>
+  <div>
+    <div
+      className="rs-layer-tree-item "
+      style={
+        Object {
+          "paddingLeft": "0px",
+        }
+      }
+    >
+      <label
+        aria-label="Show layer"
+        className="rs-layer-tree-input rs-layer-tree-input-radio rs-radio"
+        onKeyPress={[Function]}
+        tabIndex={-1}
+        title="Show layer"
+      >
+        <input
+          checked={false}
+          onClick={[Function]}
+          readOnly={true}
+          tabIndex={-1}
+          type="radio"
+        />
+        <span />
+      </label>
+      <div
+        aria-expanded={false}
+        aria-label="OpenTopoMap Show sublayer"
+        className="rs-layer-tree-toggle"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        tabIndex={0}
+        title="OpenTopoMap Show sublayer"
+      >
+        <div>
+          OpenTopoMap
+        </div>
+      </div>
+    </div>
+    <div>
+      Render name after item: 
+      OpenTopoMap
+    </div>
+  </div>
+  <div>
+    <div
+      className="rs-layer-tree-item "
+      style={
+        Object {
+          "paddingLeft": "0px",
+        }
+      }
+    >
+      <label
+        aria-label="Show layer"
+        className="rs-layer-tree-input rs-layer-tree-input-radio rs-radio"
+        onKeyPress={[Function]}
+        tabIndex={-1}
+        title="Show layer"
+      >
+        <input
+          checked={false}
+          onClick={[Function]}
+          readOnly={true}
+          tabIndex={-1}
+          type="radio"
+        />
+        <span />
+      </label>
+      <div
+        aria-expanded={false}
+        aria-label="OSM Baselayer Hot Show sublayer"
+        className="rs-layer-tree-toggle"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        tabIndex={0}
+        title="OSM Baselayer Hot Show sublayer"
+      >
+        <div>
+          OSM Baselayer Hot
+        </div>
+      </div>
+    </div>
+    <div>
+      Render name after item: 
+      OSM Baselayer Hot
+    </div>
+  </div>
+  <div>
+    <div
+      className="rs-layer-tree-item rs-visible"
+      style={
+        Object {
+          "paddingLeft": "0px",
+        }
+      }
+    >
+      <label
+        aria-label="Hide layer"
+        className="rs-layer-tree-input rs-layer-tree-input-radio rs-radio"
+        onKeyPress={[Function]}
+        tabIndex={-1}
+        title="Hide layer"
+      >
+        <input
+          checked={true}
+          onClick={[Function]}
+          readOnly={true}
+          tabIndex={-1}
+          type="radio"
+        />
+        <span />
+      </label>
+      <div
+        aria-expanded={false}
+        aria-label="OSM Baselayer Show sublayer"
+        className="rs-layer-tree-toggle"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        tabIndex={0}
+        title="OSM Baselayer Show sublayer"
+      >
+        <div>
+          OSM Baselayer
+        </div>
+      </div>
+    </div>
+    <div>
+      Render name after item: 
+      OSM Baselayer
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
+<div
+  className="rs-layer-tree"
+>
+  <div>
+    <div
+      className="rs-layer-tree-item rs-visible"
+      style={
+        Object {
+          "paddingLeft": "0px",
+        }
+      }
+    >
+      <label
+        aria-label="Hide layer"
+        className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+        onKeyPress={[Function]}
+        tabIndex={0}
+        title="Hide layer"
+      >
+        <input
+          checked={true}
+          onClick={[Function]}
+          readOnly={true}
+          tabIndex={-1}
+          type="checkbox"
+        />
+        <span />
+      </label>
+      <div
+        aria-expanded={true}
+        aria-label="Road sample layers Hide sublayer"
+        className="rs-layer-tree-toggle"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        tabIndex={0}
+        title="Road sample layers Hide sublayer"
+      >
+        <div>
+          Road sample layers
+        </div>
+        <div
+          className="rs-layer-tree-arrow rs-layer-tree-arrow-expanded"
+        />
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item rs-visible"
+        style={
+          Object {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <label
+          aria-label="Hide layer"
+          className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+          onKeyPress={[Function]}
+          tabIndex={-1}
+          title="Hide layer"
+        >
+          <input
+            checked={true}
+            onClick={[Function]}
+            readOnly={true}
+            tabIndex={-1}
+            type="checkbox"
+          />
+          <span />
+        </label>
+        <div
+          aria-expanded={false}
+          aria-label="Vienna Streets Show sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="Vienna Streets Show sublayer"
+        >
+          <div>
+            Vienna Streets
+          </div>
+        </div>
+      </div>
+      <div>
+        Render name before item: 
+        Vienna Streets
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item rs-visible"
+        style={
+          Object {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <label
+          aria-label="Hide layer"
+          className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+          onKeyPress={[Function]}
+          tabIndex={-1}
+          title="Hide layer"
+        >
+          <input
+            checked={true}
+            onClick={[Function]}
+            readOnly={true}
+            tabIndex={-1}
+            type="checkbox"
+          />
+          <span />
+        </label>
+        <div
+          aria-expanded={false}
+          aria-label="Roads Seoul Show sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="Roads Seoul Show sublayer"
+        >
+          <div>
+            Roads Seoul
+          </div>
+        </div>
+      </div>
+      <div>
+        Render name before item: 
+        Roads Seoul
+      </div>
+    </div>
+    <div>
+      Render name before item: 
+      Road sample layers
+    </div>
+  </div>
+  <div>
+    <div
+      className="rs-layer-tree-item rs-visible"
+      style={
+        Object {
+          "paddingLeft": "0px",
+        }
+      }
+    >
+      <label
+        aria-label="Hide layer"
+        className="rs-layer-tree-input rs-layer-tree-input-radio rs-radio"
+        onKeyPress={[Function]}
+        tabIndex={0}
+        title="Hide layer"
+      >
+        <input
+          checked={true}
+          onClick={[Function]}
+          readOnly={true}
+          tabIndex={-1}
+          type="radio"
+        />
+        <span />
+      </label>
+      <div
+        aria-expanded={true}
+        aria-label="Vector sample layers Hide sublayer"
+        className="rs-layer-tree-toggle"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        tabIndex={0}
+        title="Vector sample layers Hide sublayer"
+      >
+        <div>
+          Vector sample layers
+        </div>
+        <div
+          className="rs-layer-tree-arrow rs-layer-tree-arrow-expanded"
+        />
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item "
+        style={
+          Object {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <label
+          aria-label="Show layer"
+          className="rs-layer-tree-input rs-layer-tree-input-radio rs-radio"
+          onKeyPress={[Function]}
+          tabIndex={-1}
+          title="Show layer"
+        >
+          <input
+            checked={false}
+            onClick={[Function]}
+            readOnly={true}
+            tabIndex={-1}
+            type="radio"
+          />
+          <span />
+        </label>
+        <div
+          aria-expanded={false}
+          aria-label="Points Samples Show sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="Points Samples Show sublayer"
+        >
+          <div>
+            Points Samples
+          </div>
+        </div>
+      </div>
+      <div>
+        Render name before item: 
+        Points Samples
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item rs-visible"
+        style={
+          Object {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <label
+          aria-label="Hide layer"
+          className="rs-layer-tree-input rs-layer-tree-input-radio rs-radio"
+          onKeyPress={[Function]}
+          tabIndex={-1}
+          title="Hide layer"
+        >
+          <input
+            checked={true}
+            onClick={[Function]}
+            readOnly={true}
+            tabIndex={-1}
+            type="radio"
+          />
+          <span />
+        </label>
+        <div
+          aria-expanded={false}
+          aria-label="Lines Samples Show sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="Lines Samples Show sublayer"
+        >
+          <div>
+            Lines Samples
+          </div>
+        </div>
+      </div>
+      <div>
+        Render name before item: 
+        Lines Samples
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item "
+        style={
+          Object {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <label
+          aria-label="Show layer"
+          className="rs-layer-tree-input rs-layer-tree-input-radio rs-radio"
+          onKeyPress={[Function]}
+          tabIndex={-1}
+          title="Show layer"
+        >
+          <input
+            checked={false}
+            onClick={[Function]}
+            readOnly={true}
+            tabIndex={-1}
+            type="radio"
+          />
+          <span />
+        </label>
+        <div
+          aria-expanded={false}
+          aria-label="Polygons Samples Show sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="Polygons Samples Show sublayer"
+        >
+          <div>
+            Polygons Samples
+          </div>
+        </div>
+      </div>
+      <div>
+        Render name before item: 
+        Polygons Samples
+      </div>
+    </div>
+    <div>
+      Render name before item: 
+      Vector sample layers
+    </div>
+  </div>
+  <div>
+    <div
+      className="rs-layer-tree-item rs-visible"
+      style={
+        Object {
+          "paddingLeft": "0px",
+        }
+      }
+    >
+      <label
+        aria-label="Hide layer"
+        className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+        onKeyPress={[Function]}
+        tabIndex={0}
+        title="Hide layer"
+      >
+        <input
+          checked={true}
+          onClick={[Function]}
+          readOnly={true}
+          tabIndex={-1}
+          type="checkbox"
+        />
+        <span />
+      </label>
+      <div
+        aria-expanded={true}
+        aria-label="Other layers Hide sublayer"
+        className="rs-layer-tree-toggle"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        tabIndex={0}
+        title="Other layers Hide sublayer"
+      >
+        <div>
+          Other layers
+        </div>
+        <div
+          className="rs-layer-tree-arrow rs-layer-tree-arrow-expanded"
+        />
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item "
+        style={
+          Object {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <label
+          aria-label="Show layer"
+          className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+          onKeyPress={[Function]}
+          tabIndex={0}
+          title="Show layer"
+        >
+          <input
+            checked={false}
+            onClick={[Function]}
+            readOnly={true}
+            tabIndex={-1}
+            type="checkbox"
+          />
+          <span />
+        </label>
+        <div
+          aria-expanded={true}
+          aria-label="Countries Hide sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="Countries Hide sublayer"
+        >
+          <div>
+            Countries
+          </div>
+        </div>
+      </div>
+      <div>
+        <div
+          className="rs-layer-tree-item "
+          style={
+            Object {
+              "paddingLeft": "60px",
+            }
+          }
+        >
+          <label
+            aria-label="Show layer"
+            className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+            onKeyPress={[Function]}
+            tabIndex={-1}
+            title="Show layer"
+          >
+            <input
+              checked={false}
+              onClick={[Function]}
+              readOnly={true}
+              tabIndex={-1}
+              type="checkbox"
+            />
+            <span />
+          </label>
+          <div
+            aria-expanded={false}
+            aria-label="Countries Borders Show sublayer"
+            className="rs-layer-tree-toggle"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+            title="Countries Borders Show sublayer"
+          >
+            <div>
+              Countries Borders
+            </div>
+          </div>
+        </div>
+        <div>
+          Render name before item: 
+          Countries Borders
+        </div>
+      </div>
+      <div>
+        <div
+          className="rs-layer-tree-item "
+          style={
+            Object {
+              "paddingLeft": "60px",
+            }
+          }
+        >
+          <label
+            aria-label="Show layer"
+            className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+            onKeyPress={[Function]}
+            tabIndex={-1}
+            title="Show layer"
+          >
+            <input
+              checked={false}
+              onClick={[Function]}
+              readOnly={true}
+              tabIndex={-1}
+              type="checkbox"
+            />
+            <span />
+          </label>
+          <div
+            aria-expanded={false}
+            aria-label="Countries 110m Show sublayer"
+            className="rs-layer-tree-toggle"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+            title="Countries 110m Show sublayer"
+          >
+            <div>
+              Countries 110m
+            </div>
+          </div>
+        </div>
+        <div>
+          Render name before item: 
+          Countries 110m
+        </div>
+      </div>
+      <div>
+        Render name before item: 
+        Countries
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item rs-visible"
+        style={
+          Object {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <label
+          aria-label="Hide layer"
+          className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+          onKeyPress={[Function]}
+          tabIndex={-1}
+          title="Hide layer"
+        >
+          <input
+            checked={true}
+            onClick={[Function]}
+            readOnly={true}
+            tabIndex={-1}
+            type="checkbox"
+          />
+          <span />
+        </label>
+        <div
+          aria-expanded={false}
+          aria-label="USA Population Density Show sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="USA Population Density Show sublayer"
+        >
+          <div>
+            USA Population Density
+          </div>
+        </div>
+      </div>
+      <div>
+        Render name before item: 
+        USA Population Density
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item rs-visible"
+        style={
+          Object {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <label
+          aria-label="Hide layer"
+          className="rs-layer-tree-input rs-layer-tree-input-checkbox rs-checkbox"
+          onKeyPress={[Function]}
+          tabIndex={-1}
+          title="Hide layer"
+        >
+          <input
+            checked={true}
+            onClick={[Function]}
+            readOnly={true}
+            tabIndex={-1}
+            type="checkbox"
+          />
+          <span />
+        </label>
+        <div
+          aria-expanded={false}
+          aria-label="Switzerland Show sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="Switzerland Show sublayer"
+        >
+          <div>
+            Switzerland
+          </div>
+        </div>
+      </div>
+      <div>
+        Render name before item: 
+        Switzerland
+      </div>
+    </div>
+    <div>
+      Render name before item: 
+      Other layers
+    </div>
+  </div>
+  <div>
+    <div
+      className="rs-layer-tree-item "
+      style={
+        Object {
+          "paddingLeft": "0px",
+        }
+      }
+    >
+      <label
+        aria-label="Show layer"
+        className="rs-layer-tree-input rs-layer-tree-input-radio rs-radio"
+        onKeyPress={[Function]}
+        tabIndex={-1}
+        title="Show layer"
+      >
+        <input
+          checked={false}
+          onClick={[Function]}
+          readOnly={true}
+          tabIndex={-1}
+          type="radio"
+        />
+        <span />
+      </label>
+      <div
+        aria-expanded={false}
+        aria-label="OpenTopoMap Show sublayer"
+        className="rs-layer-tree-toggle"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        tabIndex={0}
+        title="OpenTopoMap Show sublayer"
+      >
+        <div>
+          OpenTopoMap
+        </div>
+      </div>
+    </div>
+    <div>
+      Render name before item: 
+      OpenTopoMap
+    </div>
+  </div>
+  <div>
+    <div
+      className="rs-layer-tree-item "
+      style={
+        Object {
+          "paddingLeft": "0px",
+        }
+      }
+    >
+      <label
+        aria-label="Show layer"
+        className="rs-layer-tree-input rs-layer-tree-input-radio rs-radio"
+        onKeyPress={[Function]}
+        tabIndex={-1}
+        title="Show layer"
+      >
+        <input
+          checked={false}
+          onClick={[Function]}
+          readOnly={true}
+          tabIndex={-1}
+          type="radio"
+        />
+        <span />
+      </label>
+      <div
+        aria-expanded={false}
+        aria-label="OSM Baselayer Hot Show sublayer"
+        className="rs-layer-tree-toggle"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        tabIndex={0}
+        title="OSM Baselayer Hot Show sublayer"
+      >
+        <div>
+          OSM Baselayer Hot
+        </div>
+      </div>
+    </div>
+    <div>
+      Render name before item: 
+      OSM Baselayer Hot
+    </div>
+  </div>
+  <div>
+    <div
+      className="rs-layer-tree-item rs-visible"
+      style={
+        Object {
+          "paddingLeft": "0px",
+        }
+      }
+    >
+      <label
+        aria-label="Hide layer"
+        className="rs-layer-tree-input rs-layer-tree-input-radio rs-radio"
+        onKeyPress={[Function]}
+        tabIndex={-1}
+        title="Hide layer"
+      >
+        <input
+          checked={true}
+          onClick={[Function]}
+          readOnly={true}
+          tabIndex={-1}
+          type="radio"
+        />
+        <span />
+      </label>
+      <div
+        aria-expanded={false}
+        aria-label="OSM Baselayer Show sublayer"
+        className="rs-layer-tree-toggle"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        tabIndex={0}
+        title="OSM Baselayer Show sublayer"
+      >
+        <div>
+          OSM Baselayer
+        </div>
+      </div>
+    </div>
+    <div>
+      Render name before item: 
+      OSM Baselayer
+    </div>
+  </div>
+</div>
+`;
+
 exports[`LayerTree matches snapshots when classNames are used. 1`] = `
 <div
   className="foo"

--- a/src/components/LayerTree/__snapshots__/LayerTree.test.js.snap
+++ b/src/components/LayerTree/__snapshots__/LayerTree.test.js.snap
@@ -1148,6 +1148,8 @@ exports[`LayerTree matches snapshots when an item use renderAfterItem. 1`] = `
       <div>
         Render name after item: 
         Vienna Streets
+        , level: 
+        1
       </div>
     </div>
     <div>
@@ -1193,11 +1195,15 @@ exports[`LayerTree matches snapshots when an item use renderAfterItem. 1`] = `
       <div>
         Render name after item: 
         Roads Seoul
+        , level: 
+        1
       </div>
     </div>
     <div>
       Render name after item: 
       Road sample layers
+      , level: 
+      0
     </div>
   </div>
   <div>
@@ -1286,6 +1292,8 @@ exports[`LayerTree matches snapshots when an item use renderAfterItem. 1`] = `
       <div>
         Render name after item: 
         Points Samples
+        , level: 
+        1
       </div>
     </div>
     <div>
@@ -1331,6 +1339,8 @@ exports[`LayerTree matches snapshots when an item use renderAfterItem. 1`] = `
       <div>
         Render name after item: 
         Lines Samples
+        , level: 
+        1
       </div>
     </div>
     <div>
@@ -1376,11 +1386,15 @@ exports[`LayerTree matches snapshots when an item use renderAfterItem. 1`] = `
       <div>
         Render name after item: 
         Polygons Samples
+        , level: 
+        1
       </div>
     </div>
     <div>
       Render name after item: 
       Vector sample layers
+      , level: 
+      0
     </div>
   </div>
   <div>
@@ -1509,6 +1523,8 @@ exports[`LayerTree matches snapshots when an item use renderAfterItem. 1`] = `
         <div>
           Render name after item: 
           Countries Borders
+          , level: 
+          2
         </div>
       </div>
       <div>
@@ -1554,11 +1570,15 @@ exports[`LayerTree matches snapshots when an item use renderAfterItem. 1`] = `
         <div>
           Render name after item: 
           Countries 110m
+          , level: 
+          2
         </div>
       </div>
       <div>
         Render name after item: 
         Countries
+        , level: 
+        1
       </div>
     </div>
     <div>
@@ -1604,6 +1624,8 @@ exports[`LayerTree matches snapshots when an item use renderAfterItem. 1`] = `
       <div>
         Render name after item: 
         USA Population Density
+        , level: 
+        1
       </div>
     </div>
     <div>
@@ -1649,11 +1671,15 @@ exports[`LayerTree matches snapshots when an item use renderAfterItem. 1`] = `
       <div>
         Render name after item: 
         Switzerland
+        , level: 
+        1
       </div>
     </div>
     <div>
       Render name after item: 
       Other layers
+      , level: 
+      0
     </div>
   </div>
   <div>
@@ -1699,6 +1725,8 @@ exports[`LayerTree matches snapshots when an item use renderAfterItem. 1`] = `
     <div>
       Render name after item: 
       OpenTopoMap
+      , level: 
+      0
     </div>
   </div>
   <div>
@@ -1744,6 +1772,8 @@ exports[`LayerTree matches snapshots when an item use renderAfterItem. 1`] = `
     <div>
       Render name after item: 
       OSM Baselayer Hot
+      , level: 
+      0
     </div>
   </div>
   <div>
@@ -1789,6 +1819,8 @@ exports[`LayerTree matches snapshots when an item use renderAfterItem. 1`] = `
     <div>
       Render name after item: 
       OSM Baselayer
+      , level: 
+      0
     </div>
   </div>
 </div>
@@ -1844,6 +1876,8 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
     <div>
       Render name before item: 
       Road sample layers
+      , level: 
+      0
     </div>
     <div>
       <div
@@ -1888,6 +1922,8 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
       <div>
         Render name before item: 
         Vienna Streets
+        , level: 
+        1
       </div>
     </div>
     <div>
@@ -1933,6 +1969,8 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
       <div>
         Render name before item: 
         Roads Seoul
+        , level: 
+        1
       </div>
     </div>
   </div>
@@ -1982,6 +2020,8 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
     <div>
       Render name before item: 
       Vector sample layers
+      , level: 
+      0
     </div>
     <div>
       <div
@@ -2026,6 +2066,8 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
       <div>
         Render name before item: 
         Points Samples
+        , level: 
+        1
       </div>
     </div>
     <div>
@@ -2071,6 +2113,8 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
       <div>
         Render name before item: 
         Lines Samples
+        , level: 
+        1
       </div>
     </div>
     <div>
@@ -2116,6 +2160,8 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
       <div>
         Render name before item: 
         Polygons Samples
+        , level: 
+        1
       </div>
     </div>
   </div>
@@ -2165,6 +2211,8 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
     <div>
       Render name before item: 
       Other layers
+      , level: 
+      0
     </div>
     <div>
       <div
@@ -2209,6 +2257,8 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
       <div>
         Render name before item: 
         Countries
+        , level: 
+        1
       </div>
       <div>
         <div
@@ -2253,6 +2303,8 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
         <div>
           Render name before item: 
           Countries Borders
+          , level: 
+          2
         </div>
       </div>
       <div>
@@ -2298,6 +2350,8 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
         <div>
           Render name before item: 
           Countries 110m
+          , level: 
+          2
         </div>
       </div>
     </div>
@@ -2344,6 +2398,8 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
       <div>
         Render name before item: 
         USA Population Density
+        , level: 
+        1
       </div>
     </div>
     <div>
@@ -2389,6 +2445,8 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
       <div>
         Render name before item: 
         Switzerland
+        , level: 
+        1
       </div>
     </div>
   </div>
@@ -2435,6 +2493,8 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
     <div>
       Render name before item: 
       OpenTopoMap
+      , level: 
+      0
     </div>
   </div>
   <div>
@@ -2480,6 +2540,8 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
     <div>
       Render name before item: 
       OSM Baselayer Hot
+      , level: 
+      0
     </div>
   </div>
   <div>
@@ -2525,6 +2587,8 @@ exports[`LayerTree matches snapshots when an item use renderBeforeItem. 1`] = `
     <div>
       Render name before item: 
       OSM Baselayer
+      , level: 
+      0
     </div>
   </div>
 </div>


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
Define a renderBeforeItem property in the LayerTree example.

```jsx
<LayerTree ... renderBeforeItem={()=>{return <div>lala</div>}} />
```

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
