### PR TITLE
Styleguide resposiveness

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.9",
   "license": "MIT",
   "dependencies": {
-    "@geops/geops-ui": "0.1.4",
+    "@geops/geops-ui": "0.1.5",
     "@material-ui/core": "^4.11.0",
     "abortcontroller-polyfill": "1.5.0",
     "file-loader": "^6.1.1",

--- a/src/styleguidist/StyleGuide.js
+++ b/src/styleguidist/StyleGuide.js
@@ -5,7 +5,7 @@ import { geopsTheme, Header, Footer } from '@geops/geops-ui';
 import {
   Hidden,
   FormControl,
-  // InputLabel,
+  InputLabel,
   Select,
   MenuItem,
   ListSubheader,
@@ -34,6 +34,12 @@ const styles = ({ mq }) => ({
   scrollable: {
     overflowY: 'scroll',
     height: 'calc(100vh - 100px)',
+    [mq.small]: {
+      top: 60,
+      position: 'absolute',
+      width: '100%',
+      height: 'calc(100vh - 160px)',
+    },
   },
   main: {
     maxWidth: 1000,
@@ -42,7 +48,6 @@ const styles = ({ mq }) => ({
     paddingTop: 50,
     margin: [[0, 'auto']],
     [mq.small]: {
-      marginTop: 50,
       padding: 15,
     },
     display: 'block',
@@ -68,16 +73,6 @@ const styles = ({ mq }) => ({
     zIndex: 99999,
   },
 });
-
-const muiStyles = {
-  subHeader: {
-    fontWeight: 'bold',
-    fontSize: 20,
-  },
-  dropdownItem: {
-    fontSize: 15,
-  },
-};
 
 const links = [
   {
@@ -126,50 +121,73 @@ export function StyleGuideRenderer({
           tabs={[{ label: 'Code', href: `${docConfig.githubRepo}` }]}
         />
         <div className={classes.content}>
+          <Hidden mdUp>
+            <div className={classes.dropdown}>
+              <FormControl fullWidth>
+                <InputLabel
+                  style={{
+                    paddingLeft: 10,
+                    paddingBottom: 10,
+                  }}
+                  id="component-select"
+                >
+                  Components
+                </InputLabel>
+                <Select
+                  style={{
+                    paddingLeft: 10,
+                    paddingBottom: 10,
+                  }}
+                  defaultValue=""
+                  id="component-select"
+                  labelWidth={20}
+                  autoWidth
+                >
+                  {toc.props.sections.slice(1).map((section) => {
+                    return [
+                      <ListSubheader
+                        style={{
+                          fontWeight: 'bold',
+                          fontSize: 20,
+                        }}
+                        disableSticky
+                        value={section.name}
+                      >
+                        <Link
+                          style={{ display: 'block', width: '100%' }}
+                          href={`#section-${section.name.toLowerCase()}`}
+                        >
+                          {section.name}
+                        </Link>
+                      </ListSubheader>,
+                      ...section.components.map((component) => {
+                        return (
+                          <MenuItem
+                            style={{ display: 'block', width: '100%' }}
+                            value={component.name}
+                          >
+                            <Link
+                              style={{ display: 'block', width: '100%' }}
+                              href={`#${component.name.toLowerCase()}`}
+                            >
+                              {component.name}
+                            </Link>
+                          </MenuItem>
+                        );
+                      }),
+                    ];
+                  })}
+                </Select>
+              </FormControl>
+            </div>
+          </Hidden>
           <div className={classes.scrollable}>
-            <Hidden mdDown>
+            <Hidden smDown>
               <div className={classes.sidebar}>
                 <header className={classes.version}>
                   {version && <Version>{version}</Version>}
                 </header>
                 {hasSidebar ? toc : null}
-              </div>
-            </Hidden>
-            <Hidden mdUp>
-              <div className={classes.dropdown}>
-                <FormControl fullWidth>
-                  <Select defaultValue="" id="component-select" labelWidth={20}>
-                    {/* <InputLabel htmlFor="component-select">
-                      Components
-                    </InputLabel> */}
-                    {/* <MenuItem value="">
-                      <Link href="/">Reset</Link>
-                    </MenuItem> */}
-                    {toc.props.sections.slice(0).map((section) => {
-                      return (
-                        <div>
-                          <ListSubheader
-                            style={muiStyles.subHeader}
-                            disableSticky
-                          >
-                            <Link
-                              href={`#section-${section.name.toLowerCase()}`}
-                            >
-                              {section.name}
-                            </Link>
-                          </ListSubheader>
-                          {section.components.map((component) => (
-                            <MenuItem value={component.name}>
-                              <Link href={`#${component.name.toLowerCase()}`}>
-                                {component.name}
-                              </Link>
-                            </MenuItem>
-                          ))}
-                        </div>
-                      );
-                    })}
-                  </Select>
-                </FormControl>
               </div>
             </Hidden>
             <main className={classes.main}>{children}</main>

--- a/src/styleguidist/StyleGuide.js
+++ b/src/styleguidist/StyleGuide.js
@@ -2,6 +2,15 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { geopsTheme, Header, Footer } from '@geops/geops-ui';
+import {
+  Hidden,
+  FormControl,
+  // InputLabel,
+  Select,
+  MenuItem,
+  ListSubheader,
+  Link,
+} from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/core/styles';
 import Version from 'react-styleguidist/lib/client/rsg-components/Version';
 import Styled from 'react-styleguidist/lib/client/rsg-components/Styled';
@@ -17,7 +26,6 @@ const styles = ({ mq }) => ({
   content: {
     top: 100,
     bottom: 0,
-    marginBottom: 70,
     height: 'calc(100vh - 60px)',
     position: 'fixed',
     width: '100%',
@@ -25,14 +33,16 @@ const styles = ({ mq }) => ({
   },
   scrollable: {
     overflowY: 'scroll',
-    height: 'calc(100vh - 170px)',
+    height: 'calc(100vh - 100px)',
   },
   main: {
     maxWidth: 1000,
     padding: [[15, 30]],
-    paddingLeft: '230px',
+    paddingLeft: 230,
+    paddingTop: 50,
     margin: [[0, 'auto']],
     [mq.small]: {
+      marginTop: 50,
       padding: 15,
     },
     display: 'block',
@@ -48,11 +58,26 @@ const styles = ({ mq }) => ({
     top: 100,
     left: 0,
     bottom: 0,
-    marginBottom: 70,
     width: '200px',
     overflow: 'auto',
   },
+  dropdown: {
+    position: 'fixed',
+    backgroundColor: '#EFEFEF',
+    width: '100%',
+    zIndex: 99999,
+  },
 });
+
+const muiStyles = {
+  subHeader: {
+    fontWeight: 'bold',
+    fontSize: 20,
+  },
+  dropdownItem: {
+    fontSize: 15,
+  },
+};
 
 const links = [
   {
@@ -102,13 +127,53 @@ export function StyleGuideRenderer({
         />
         <div className={classes.content}>
           <div className={classes.scrollable}>
-            <div className={classes.sidebar}>
-              <header className={classes.version}>
-                {version && <Version>{version}</Version>}
-              </header>
-              {hasSidebar ? toc : null}
-            </div>
+            <Hidden mdDown>
+              <div className={classes.sidebar}>
+                <header className={classes.version}>
+                  {version && <Version>{version}</Version>}
+                </header>
+                {hasSidebar ? toc : null}
+              </div>
+            </Hidden>
+            <Hidden mdUp>
+              <div className={classes.dropdown}>
+                <FormControl fullWidth>
+                  <Select defaultValue="" id="component-select" labelWidth={20}>
+                    {/* <InputLabel htmlFor="component-select">
+                      Components
+                    </InputLabel> */}
+                    {/* <MenuItem value="">
+                      <Link href="/">Reset</Link>
+                    </MenuItem> */}
+                    {toc.props.sections.slice(0).map((section) => {
+                      return (
+                        <div>
+                          <ListSubheader
+                            style={muiStyles.subHeader}
+                            disableSticky
+                          >
+                            <Link
+                              href={`#section-${section.name.toLowerCase()}`}
+                            >
+                              {section.name}
+                            </Link>
+                          </ListSubheader>
+                          {section.components.map((component) => (
+                            <MenuItem value={component.name}>
+                              <Link href={`#${component.name.toLowerCase()}`}>
+                                {component.name}
+                              </Link>
+                            </MenuItem>
+                          ))}
+                        </div>
+                      );
+                    })}
+                  </Select>
+                </FormControl>
+              </div>
+            </Hidden>
             <main className={classes.main}>{children}</main>
+            <Footer links={links} />
           </div>
         </div>
         <div id="promo">
@@ -121,7 +186,6 @@ export function StyleGuideRenderer({
           </a>
         </div>
       </div>
-      <Footer links={links} />
     </ThemeProvider>
   );
 }

--- a/src/styleguidist/styleguidist.css
+++ b/src/styleguidist/styleguidist.css
@@ -5,8 +5,8 @@
 }
 
 #promo {
-  position: absolute;
-  bottom: 120px;
+  position: fixed;
+  bottom: 55px;
   background-color: #e90;
   right: -65px;
   transform: rotate(-45deg);
@@ -26,4 +26,8 @@
 #promo a,
 #promo a:hover {
   text-decoration: none;
+}
+
+footer {
+  position: relative;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1386,10 +1386,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@geops/geops-ui@0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@geops/geops-ui/-/geops-ui-0.1.4.tgz#0c4d0a2a83e571b2b7536fda09d01ec6f5c62d7e"
-  integrity sha512-z/ldNH/VZ0pd8hsKeG4Xz74GHaD9CUsY4wqC/nQs0zHamHDmwr/zqfknIhJaL41W/lM0rKKkiMhVoL0lAjcVwQ==
+"@geops/geops-ui@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@geops/geops-ui/-/geops-ui-0.1.5.tgz#104961a9776b0748f274d68e2cf5ddd915a6dbd0"
+  integrity sha512-M6v4FVwC//Han6hizEdHeSy7R2xObYTJCq4zpHZMVlT2Mnwt1tfr1j3I9YvJqcTqAqqVZnUfrt15FOqyL+eFag==
   dependencies:
     "@material-ui/core" "^4.11.0"
     "@material-ui/icons" "^4.9.1"


### PR DESCRIPTION
# How to

The styleguide for react-spatial is not responsive and breaks on mobile devices. 
Updates:
- Removed sidebar on lower resolutions
- Added MUI Select for lower resolutions
- Moved Footer to content div (not fixed to bottom of viewport)

Test: Use the netlify preview app and test on different resolutions

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
