### PR TITLE
Upgrade geops-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.9",
   "license": "MIT",
   "dependencies": {
-    "@geops/geops-ui": "0.1.5",
+    "@geops/geops-ui": "0.1.8",
     "@material-ui/core": "^4.11.0",
     "abortcontroller-polyfill": "1.5.0",
     "file-loader": "^6.1.1",

--- a/src/styleguidist/StyleGuide.js
+++ b/src/styleguidist/StyleGuide.js
@@ -74,17 +74,6 @@ const styles = ({ mq }) => ({
   },
 });
 
-const links = [
-  {
-    label: 'Privacy Policy',
-    href: 'https://geops.ch/datenschutz',
-  },
-  {
-    label: 'Imprint',
-    href: 'https://geops.ch/impressum',
-  },
-];
-
 export function StyleGuideRenderer({
   classes,
   children,
@@ -191,7 +180,7 @@ export function StyleGuideRenderer({
               </div>
             </Hidden>
             <main className={classes.main}>{children}</main>
-            <Footer links={links} />
+            <Footer />
           </div>
         </div>
         <div id="promo">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1386,19 +1386,15 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@geops/geops-ui@0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@geops/geops-ui/-/geops-ui-0.1.5.tgz#104961a9776b0748f274d68e2cf5ddd915a6dbd0"
-  integrity sha512-M6v4FVwC//Han6hizEdHeSy7R2xObYTJCq4zpHZMVlT2Mnwt1tfr1j3I9YvJqcTqAqqVZnUfrt15FOqyL+eFag==
+"@geops/geops-ui@0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@geops/geops-ui/-/geops-ui-0.1.8.tgz#4df8f4bb8916d762e8b9667cf744fa8961c3598d"
+  integrity sha512-ms3zDcXThMEoVP4wswdMZNajIlwr1mBlFDmtoe4qS1eN7b6iBgd3I2jJ1zSRSbuhaKMmyw7KX+iJcLv3/jY0zg==
   dependencies:
     "@material-ui/core" "^4.11.0"
     "@material-ui/icons" "^4.9.1"
-    node-sass "^4.14.1"
     prop-types "^15.7.2"
-    react "^16.13.1"
-    react-dom "^16.13.1"
     react-router-dom "^5.2.0"
-    typeface-lato "^0.0.75"
     uuid "^8.3.1"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
@@ -9368,7 +9364,7 @@ node-releases@^1.1.29, node-releases@^1.1.53:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.56.tgz#bc054a417d316e3adac90eafb7e1932802f28705"
   integrity sha512-EVo605FhWLygH8a64TjgpjyHYOihkxECwX1bHHr8tETJKWEiWS2YJjPbvsX2jFjnjTNEgBCmk9mLjKG1Mf11cw==
 
-node-sass@4.14.1, node-sass@^4.14.1:
+node-sass@4.14.1:
   version "4.14.1"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.14.1.tgz#99c87ec2efb7047ed638fb4c9db7f3a42e2217b5"
   integrity sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==


### PR DESCRIPTION
# How to
Updates:
- Upgrade geops-ui to 0.1.8
- geops-ui 0.1.8 includes the footer links by default, so they were removed from react spatial

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
