### PR TITLE
Disable zoom buttons on min/max zoom

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "1.0.11-beta.2",
+  "version": "1.0.11-beta.3",
   "license": "MIT",
   "dependencies": {
     "@geops/geops-ui": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "1.0.11-beta.3",
+  "version": "1.0.11-beta.4",
   "license": "MIT",
   "dependencies": {
     "@geops/geops-ui": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "1.0.11-beta.1",
+  "version": "1.0.11-beta.2",
   "license": "MIT",
   "dependencies": {
     "@geops/geops-ui": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "1.0.9",
+  "version": "1.0.11-beta.1",
   "license": "MIT",
   "dependencies": {
     "@geops/geops-ui": "0.1.5",

--- a/src/components/Zoom/Zoom.js
+++ b/src/components/Zoom/Zoom.js
@@ -81,6 +81,7 @@ function Zoom({
     zoomIn: false,
     zoomOut: false,
   });
+  const [currentZoom, setZoom] = useState();
 
   const zoomIn = useCallback(
     (evt) => {
@@ -106,15 +107,19 @@ function Zoom({
       zoomIn: map.getView().getZoom() >= getZoomLimits(map).maxZoom,
       zoomOut: map.getView().getZoom() <= getZoomLimits(map).minZoom,
     });
+    setZoom(map.getView().getZoom());
     map.getView().on('change', () => {
       // Add listener to set disabled zoom controls on view change
-      const zoom = map.getView().getZoom();
-      setDisabledControls({
-        zoomIn: zoom >= getZoomLimits(map).maxZoom,
-        zoomOut: zoom <= getZoomLimits(map).minZoom,
-      });
+      setZoom(map.getView().getZoom());
     });
   }, []);
+
+  useEffect(() => {
+    setDisabledControls({
+      zoomIn: map.getView().getZoom() >= getZoomLimits(map).maxZoom,
+      zoomOut: map.getView().getZoom() <= getZoomLimits(map).minZoom,
+    });
+  }, [currentZoom]);
 
   useEffect(() => {
     let control;

--- a/src/components/Zoom/Zoom.js
+++ b/src/components/Zoom/Zoom.js
@@ -98,23 +98,22 @@ function Zoom({
 
   const zoomInDisabled = useMemo(() => {
     return (
-      map.getView().getZoom() >=
+      currentZoom >=
       map.getView().getConstrainedZoom(map.getView().getMaxZoom())
     );
   }, [currentZoom]);
 
   const zoomOutDisabled = useMemo(() => {
     return (
-      map.getView().getZoom() <=
+      currentZoom <=
       map.getView().getConstrainedZoom(map.getView().getMinZoom())
     );
   }, [currentZoom]);
 
   useEffect(() => {
-    /* Trigger recalculation of disabled zooms */
-    map.on('moveend', () => {
-      setZoom(map.getView().getZoom());
-    });
+    /* Trigger zoom update to disable zooms on max and min */
+    const zoomListener = () => setZoom(map.getView().getZoom());
+    map.on('moveend', zoomListener);
 
     let control;
     if (zoomSlider && ref.current) {
@@ -126,6 +125,7 @@ function Zoom({
       map.addControl(control);
     }
     return () => {
+      map.un('moveend', zoomListener);
       if (control) {
         map.removeControl(control);
       }

--- a/src/components/Zoom/Zoom.js
+++ b/src/components/Zoom/Zoom.js
@@ -50,13 +50,25 @@ const defaultProps = {
   delta: 1,
 };
 
-const updateZoom = (map, zoomAction) => {
+const updateZoom = (map, zoomAction, zoomLimits) => {
   map.getView().cancelAnimations();
   const zoom = map.getView().getZoom();
 
-  map.getView().animate({
-    zoom: zoom + zoomAction,
-  });
+  if (zoomAction > 0 && zoom + zoomAction <= zoomLimits.maxZoom) {
+    return map.getView().animate({
+      zoom:
+        zoomAction > 0 && zoom + zoomAction <= zoomLimits.maxZoom
+          ? zoom + zoomAction
+          : zoomLimits.maxZoom,
+    });
+  }
+  // console.log(zoom + zoomAction);
+  // console.log(zoomLimits.minZoom);
+  if (zoomAction < 0 && zoom + zoomAction >= zoomLimits.minZoom) {
+    return map.getView().animate({
+      zoom: zoom + zoomAction,
+    });
+  }
 };
 
 /**
@@ -75,7 +87,10 @@ function Zoom({
   const zoomIn = useCallback(
     (evt) => {
       if (!evt.which || evt.which === 13) {
-        updateZoom(map, delta);
+        updateZoom(map, delta, {
+          minZoom: map.getView().getMinZoom(),
+          maxZoom: map.getView().getMaxZoom(),
+        });
       }
     },
     [map],
@@ -84,7 +99,10 @@ function Zoom({
   const zoomOut = useCallback(
     (evt) => {
       if (!evt.which || evt.which === 13) {
-        updateZoom(map, -delta);
+        updateZoom(map, -delta, {
+          minZoom: map.getView().getMinZoom(),
+          maxZoom: map.getView().getMaxZoom(),
+        });
       }
     },
     [map],

--- a/src/components/Zoom/Zoom.js
+++ b/src/components/Zoom/Zoom.js
@@ -101,7 +101,7 @@ function Zoom({
      * using setZoom & currentZoom, which ensures it is written on mount and update.
      */
     setZoom(view.getZoom());
-    view.on('change', () => {
+    view.on('propertychange', () => {
       /* Add view listener to trigger zoom update on view change. */
       setZoom(view.getZoom());
     });
@@ -121,7 +121,7 @@ function Zoom({
      * between certain topics in Trafimage-Maps)
      */
     map.on('change:view', () => {
-      map.getView().on('change', () => {
+      map.getView().on('propertychange', () => {
         setZoom(map.getView().getZoom());
       });
     });

--- a/src/components/Zoom/Zoom.scss
+++ b/src/components/Zoom/Zoom.scss
@@ -16,6 +16,12 @@
     justify-content: center;
     align-items: center;
     transition: background-color 0.5s ease, color 0.5s ease;
+    border: none;
+  }
+
+  .rs-zoom-disabled {
+    pointer-events: none;
+    opacity: 0.4;
   }
 
   .rs-zoomslider-wrapper {

--- a/src/components/Zoom/Zoom.scss
+++ b/src/components/Zoom/Zoom.scss
@@ -17,11 +17,11 @@
     align-items: center;
     transition: background-color 0.5s ease, color 0.5s ease;
     border: none;
-  }
 
-  .rs-zoom-disabled {
-    pointer-events: none;
-    opacity: 0.4;
+    &:disabled {
+      pointer-events: none;
+      opacity: 0.4;
+    }
   }
 
   .rs-zoomslider-wrapper {

--- a/src/components/Zoom/Zoom.test.js
+++ b/src/components/Zoom/Zoom.test.js
@@ -86,9 +86,9 @@ describe('Zoom', () => {
     const spy = jest.spyOn(map, 'removeControl');
     const spy2 = jest.spyOn(map, 'addControl');
     const wrapper = mount(<Zoom map={map} zoomSlider />);
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledTimes(0);
     wrapper.unmount();
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(1);
     expect(spy.mock.calls[0][0]).toBe(spy2.mock.calls[0][0]);
   });
 
@@ -98,9 +98,7 @@ describe('Zoom', () => {
     });
     const spy = jest.spyOn(map.getView(), 'setZoom');
     const wrapper = mount(<Zoom map={map} />);
-    expect(wrapper.find('.rs-zoom-in').hasClass('rs-zoom-disabled')).toEqual(
-      true,
-    );
+    expect(wrapper.find('.rs-zoom-in').prop('disabled')).toEqual(true);
     wrapper.find('.rs-zoom-in').first().simulate('click');
     expect(spy).toHaveBeenCalledTimes(0);
   });
@@ -111,9 +109,7 @@ describe('Zoom', () => {
     });
     const spy = jest.spyOn(map.getView(), 'setZoom');
     const wrapper = mount(<Zoom map={map} />);
-    expect(wrapper.find('.rs-zoom-out').hasClass('rs-zoom-disabled')).toEqual(
-      true,
-    );
+    expect(wrapper.find('.rs-zoom-out').prop('disabled')).toEqual(true);
     wrapper.find('.rs-zoom-out').first().simulate('click');
     expect(spy).toHaveBeenCalledTimes(0);
   });

--- a/src/components/Zoom/Zoom.test.js
+++ b/src/components/Zoom/Zoom.test.js
@@ -86,9 +86,35 @@ describe('Zoom', () => {
     const spy = jest.spyOn(map, 'removeControl');
     const spy2 = jest.spyOn(map, 'addControl');
     const wrapper = mount(<Zoom map={map} zoomSlider />);
-    expect(spy).toHaveBeenCalledTimes(0);
-    wrapper.unmount();
     expect(spy).toHaveBeenCalledTimes(1);
+    wrapper.unmount();
+    expect(spy).toHaveBeenCalledTimes(2);
     expect(spy.mock.calls[0][0]).toBe(spy2.mock.calls[0][0]);
+  });
+
+  test('disable zoom-in button when reaching max zoom.', () => {
+    const map = new OLMap({
+      view: new OLView({ maxZoom: 20, zoom: 20 }),
+    });
+    const spy = jest.spyOn(map.getView(), 'setZoom');
+    const wrapper = mount(<Zoom map={map} />);
+    expect(wrapper.find('.rs-zoom-in').hasClass('rs-zoom-disabled')).toEqual(
+      true,
+    );
+    wrapper.find('.rs-zoom-in').first().simulate('click');
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
+
+  test('disable zoom-out button when reaching min zoom.', () => {
+    const map = new OLMap({
+      view: new OLView({ minZoom: 2, zoom: 2 }),
+    });
+    const spy = jest.spyOn(map.getView(), 'setZoom');
+    const wrapper = mount(<Zoom map={map} />);
+    expect(wrapper.find('.rs-zoom-out').hasClass('rs-zoom-disabled')).toEqual(
+      true,
+    );
+    wrapper.find('.rs-zoom-out').first().simulate('click');
+    expect(spy).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/components/Zoom/Zoom.test.js
+++ b/src/components/Zoom/Zoom.test.js
@@ -2,6 +2,8 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { configure, shallow, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { act } from 'react-dom/test-utils';
+import MapEvent from 'ol/MapEvent';
 import OLView from 'ol/View';
 import OLMap from 'ol/Map';
 import Zoom from './Zoom';
@@ -81,7 +83,7 @@ describe('Zoom', () => {
     });
   });
 
-  test('remove zoomSlider control on unmount.', () => {
+  test('should remove zoomSlider control on unmount.', () => {
     const map = new OLMap({});
     const spy = jest.spyOn(map, 'removeControl');
     const spy2 = jest.spyOn(map, 'addControl');
@@ -92,25 +94,48 @@ describe('Zoom', () => {
     expect(spy.mock.calls[0][0]).toBe(spy2.mock.calls[0][0]);
   });
 
-  test('disable zoom-in button when reaching max zoom.', () => {
+  test('should disable zoom-in button on mount with max zoom..', () => {
     const map = new OLMap({
       view: new OLView({ maxZoom: 20, zoom: 20 }),
     });
     const spy = jest.spyOn(map.getView(), 'setZoom');
     const wrapper = mount(<Zoom map={map} />);
+    act(() => {
+      map.dispatchEvent(new MapEvent('moveend', map));
+    });
+    wrapper.update();
     expect(wrapper.find('.rs-zoom-in').prop('disabled')).toEqual(true);
     wrapper.find('.rs-zoom-in').first().simulate('click');
     expect(spy).toHaveBeenCalledTimes(0);
   });
 
-  test('disable zoom-out button when reaching min zoom.', () => {
+  test('should disable zoom-out button on mount with min zoom.', () => {
     const map = new OLMap({
       view: new OLView({ minZoom: 2, zoom: 2 }),
     });
     const spy = jest.spyOn(map.getView(), 'setZoom');
     const wrapper = mount(<Zoom map={map} />);
+    act(() => {
+      map.dispatchEvent(new MapEvent('moveend', map));
+    });
+    wrapper.update();
     expect(wrapper.find('.rs-zoom-out').prop('disabled')).toEqual(true);
     wrapper.find('.rs-zoom-out').first().simulate('click');
     expect(spy).toHaveBeenCalledTimes(0);
   });
+});
+
+test('should disable zoom-out button when reaching min zoom.', () => {
+  const map = new OLMap({
+    view: new OLView({ minZoom: 2, zoom: 3 }),
+  });
+  const spy = jest.spyOn(map.getView(), 'setZoom');
+  const wrapper = mount(<Zoom map={map} />);
+  wrapper.find('.rs-zoom-out').first().simulate('click');
+  expect(spy).toHaveBeenCalledTimes(1);
+  act(() => {
+    map.dispatchEvent(new MapEvent('moveend', map));
+  });
+  wrapper.update();
+  expect(wrapper.find('.rs-zoom-out').prop('disabled')).toEqual(true);
 });

--- a/src/components/Zoom/__snapshots__/Zoom.test.js.snap
+++ b/src/components/Zoom/__snapshots__/Zoom.test.js.snap
@@ -6,13 +6,14 @@ exports[`Zoom should match snapshot with custom attributes 1`] = `
   tabIndex={-1}
   title="bar"
 >
-  <div
+  <button
     className="rs-zoom-in"
+    disabled={false}
     onClick={[Function]}
     onKeyPress={[Function]}
-    role="button"
     tabIndex={0}
     title="Zoom in"
+    type="button"
   >
     <svg
       fill="currentColor"
@@ -33,14 +34,15 @@ exports[`Zoom should match snapshot with custom attributes 1`] = `
         d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
       />
     </svg>
-  </div>
-  <div
+  </button>
+  <button
     className="rs-zoom-out"
+    disabled={false}
     onClick={[Function]}
     onKeyPress={[Function]}
-    role="button"
     tabIndex={0}
     title="Zoom out"
+    type="button"
   >
     <svg
       fill="currentColor"
@@ -61,7 +63,7 @@ exports[`Zoom should match snapshot with custom attributes 1`] = `
         d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
       />
     </svg>
-  </div>
+  </button>
 </div>
 `;
 
@@ -69,13 +71,14 @@ exports[`Zoom should match snapshot with zoom slider 1`] = `
 <div
   className="rs-zooms-bar"
 >
-  <div
+  <button
     className="rs-zoom-in"
+    disabled={false}
     onClick={[Function]}
     onKeyPress={[Function]}
-    role="button"
     tabIndex={0}
     title="Zoom in"
+    type="button"
   >
     <svg
       fill="currentColor"
@@ -96,17 +99,18 @@ exports[`Zoom should match snapshot with zoom slider 1`] = `
         d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
       />
     </svg>
-  </div>
+  </button>
   <div
     className="rs-zoomslider-wrapper"
   />
-  <div
+  <button
     className="rs-zoom-out"
+    disabled={false}
     onClick={[Function]}
     onKeyPress={[Function]}
-    role="button"
     tabIndex={0}
     title="Zoom out"
+    type="button"
   >
     <svg
       fill="currentColor"
@@ -127,7 +131,7 @@ exports[`Zoom should match snapshot with zoom slider 1`] = `
         d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
       />
     </svg>
-  </div>
+  </button>
 </div>
 `;
 
@@ -135,13 +139,14 @@ exports[`Zoom should match snapshot. 1`] = `
 <div
   className="rs-zooms-bar"
 >
-  <div
+  <button
     className="rs-zoom-in"
+    disabled={false}
     onClick={[Function]}
     onKeyPress={[Function]}
-    role="button"
     tabIndex={0}
     title="Zoom in"
+    type="button"
   >
     <svg
       fill="currentColor"
@@ -162,14 +167,15 @@ exports[`Zoom should match snapshot. 1`] = `
         d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
       />
     </svg>
-  </div>
-  <div
+  </button>
+  <button
     className="rs-zoom-out"
+    disabled={false}
     onClick={[Function]}
     onKeyPress={[Function]}
-    role="button"
     tabIndex={0}
     title="Zoom out"
+    type="button"
   >
     <svg
       fill="currentColor"
@@ -190,6 +196,6 @@ exports[`Zoom should match snapshot. 1`] = `
         d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
       />
     </svg>
-  </div>
+  </button>
 </div>
 `;


### PR DESCRIPTION
# How to

Hooks were added in the Zoom component, listening to the map view.
The zoom buttons are disabled respectively if min or max levels are reached.

Successfully tested in trafimage-maps and mapset

# Others

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
