### PR TITLE
Add line icon zIndex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "1.0.14",
+  "version": "1.0.15-beta.0",
   "license": "MIT",
   "dependencies": {
     "@geops/geops-ui": "0.1.8",

--- a/src/utils/KML.js
+++ b/src/utils/KML.js
@@ -51,6 +51,7 @@ const getLineIcon = (feature, icon, color, start = true) => {
       scale: icon.scale,
       imgSize: icon.size, // ie 11
     }),
+    zIndex: icon.zIndex,
   });
 };
 
@@ -436,6 +437,7 @@ const writeFeatures = (layer, featureProjection, mapResolution) => {
               url: extraLineStyle.getImage().getSrc(),
               scale: extraLineStyle.getImage().getScale(),
               size: extraLineStyle.getImage().getSize(),
+              zIndex: extraLineStyle.getZIndex(),
             }),
           );
         } else {
@@ -445,6 +447,7 @@ const writeFeatures = (layer, featureProjection, mapResolution) => {
               url: extraLineStyle.getImage().getSrc(),
               scale: extraLineStyle.getImage().getScale(),
               size: extraLineStyle.getImage().getSize(),
+              zIndex: extraLineStyle.getZIndex(),
             }),
           );
         }

--- a/src/utils/KML.test.js
+++ b/src/utils/KML.test.js
@@ -45,8 +45,8 @@ describe('KML', () => {
                 </Style>
                 <ExtendedData>
                   <Data name="lineDash"><value>40,40</value></Data>
-                  <Data name="lineEndIcon"><value>{"url":"fooarrowend.png","scale":0.35,"size":[36,58]}</value></Data>
-                  <Data name="lineStartIcon"><value>{"url":"fooarrowstart.png","scale":0.35,"size":[36,58]}</value></Data>
+                  <Data name="lineEndIcon"><value>{"url":"fooarrowend.png","scale":0.35,"size":[36,58],"zIndex":1}</value></Data>
+                  <Data name="lineStartIcon"><value>{"url":"fooarrowstart.png","scale":0.35,"size":[36,58],"zIndex":1}</value></Data>
                 </ExtendedData>
                 <LineString><coordinates>0,1,0 3,5,0 40,25,0</coordinates></LineString>
             </Placemark>
@@ -75,6 +75,7 @@ describe('KML', () => {
         1,
         0,
       ]);
+      expect(lineStartStyle.getZIndex()).toEqual(1);
 
       // line end icon
       const lineEndStyle = styles[2];
@@ -88,6 +89,7 @@ describe('KML', () => {
         25,
         0,
       ]);
+      expect(lineEndStyle.getZIndex()).toEqual(1);
 
       expectWriteResult(feats, str);
     });


### PR DESCRIPTION
# How to

The line icons currently have no z-Index support

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
