### PR TITLE
KML: Add methods for writing, removing and reading <Camera> tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "1.0.31-beta.1",
+  "version": "1.0.31-beta.2",
   "license": "MIT",
   "dependencies": {
     "@geops/geops-ui": "0.1.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "1.0.31-beta.11",
+  "version": "1.0.31-beta.1",
   "license": "MIT",
   "dependencies": {
     "@geops/geops-ui": "0.1.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "1.0.31-beta.1",
+  "version": "1.0.31-beta.11",
   "license": "MIT",
   "dependencies": {
     "@geops/geops-ui": "0.1.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "1.0.31-beta.0",
+  "version": "1.0.31-beta.1",
   "license": "MIT",
   "dependencies": {
     "@geops/geops-ui": "0.1.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "1.0.30",
+  "version": "1.0.31-beta.0",
   "license": "MIT",
   "dependencies": {
     "@geops/geops-ui": "0.1.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-spatial",
   "description": "Components to build React map apps.",
-  "version": "1.0.31-beta.2",
+  "version": "1.0.31-beta.3",
   "license": "MIT",
   "dependencies": {
     "@geops/geops-ui": "0.1.11",

--- a/src/utils/KML.js
+++ b/src/utils/KML.js
@@ -586,30 +586,9 @@ const writeDocumentCamera = (kmlString, cameraAttributes) => {
   return new XMLSerializer().serializeToString(kmlDoc);
 };
 
-/**
- * Read the <Camera> tag from a KML document. Returns an object containing the <Camera> attributes as keys + values
- * @param {String} kmlString A string representing a KML file.
- */
-const readDocumentCamera = (kmlString) => {
-  const cameraObject = {};
-  const kmlDoc = parse(kmlString);
-  const cameraNode = kmlDoc.getElementsByTagName('Camera')[0];
-  if (cameraNode && cameraNode.childNodes.length) {
-    cameraNode.childNodes.forEach((node) => {
-      cameraObject[`${node.nodeName.toLowerCase()}`] = !Number.isNaN(
-        parseFloat(node.innerHTML),
-      )
-        ? parseFloat(node.innerHTML)
-        : node.innerHTML;
-    });
-  }
-  return cameraObject;
-};
-
 export default {
   readFeatures,
   writeFeatures,
   writeDocumentCamera,
   removeDocumentCamera,
-  readDocumentCamera,
 };

--- a/src/utils/KML.js
+++ b/src/utils/KML.js
@@ -5,6 +5,7 @@ import MultiPoint from 'ol/geom/MultiPoint';
 import GeometryCollection from 'ol/geom/GeometryCollection';
 import { Style, Text, Icon, Circle, Fill, Stroke } from 'ol/style';
 import { asString } from 'ol/color';
+import { parse } from 'ol/xml';
 import { kmlStyle } from './Styles';
 import getPolygonPattern from './getPolygonPattern';
 
@@ -545,4 +546,61 @@ const writeFeatures = (layer, featureProjection, mapResolution) => {
   return featString;
 };
 
-export default { readFeatures, writeFeatures };
+/**
+ * Write the <Camera> tag into a KML document. Returns the KML string with added <Camera> tag
+ * @param {String} kmlString A string representing a KML file.
+ * @param {Object} cameraAttributes Object containing the camera tags (longitude, latitude, altitude, heading, tilt, altitudeMode, roll)
+ *    as keys with corresponding values. See https://developers.google.com/kml/documentation/kmlreference#camera
+ */
+const writeDocumentCamera = (kmlString, cameraAttributes) => {
+  const kmlDoc = parse(kmlString);
+
+  // Remove old Camera node
+  const oldCameraNode = kmlDoc.getElementsByTagName('Camera')[0];
+  if (oldCameraNode) {
+    oldCameraNode.remove();
+  }
+
+  if (cameraAttributes) {
+    // Create Camera node with child attributes if the cameraAttributes object is defined
+    const cameraNode = kmlDoc.createElement('Camera');
+    Object.keys(cameraAttributes).forEach((key) => {
+      const cameraAttribute = kmlDoc.createElement(
+        `${key.charAt(0).toUpperCase() + key.slice(1)}`,
+      );
+      cameraAttribute.innerHTML = cameraAttributes[key];
+      cameraNode.appendChild(cameraAttribute);
+    });
+    const documentNode = kmlDoc.getElementsByTagName('Document')[0];
+    documentNode.appendChild(cameraNode);
+  }
+
+  return new XMLSerializer().serializeToString(kmlDoc);
+};
+
+/**
+ * Read the <Camera> tag from a KML document. Returns an object containing the <Camera> attributes as keys + values
+ * @param {String} kmlString A string representing a KML file.
+ */
+const readDocumentCamera = (kmlString) => {
+  const cameraObject = {};
+  const kmlDoc = parse(kmlString);
+  const cameraNode = kmlDoc.getElementsByTagName('Camera')[0];
+  if (cameraNode && cameraNode.childNodes.length) {
+    cameraNode.childNodes.forEach((node) => {
+      cameraObject[`${node.nodeName.toLowerCase()}`] = !Number.isNaN(
+        parseFloat(node.innerHTML),
+      )
+        ? parseFloat(node.innerHTML)
+        : node.innerHTML;
+    });
+  }
+  return cameraObject;
+};
+
+export default {
+  readFeatures,
+  writeFeatures,
+  writeDocumentCamera,
+  readDocumentCamera,
+};

--- a/src/utils/KML.js
+++ b/src/utils/KML.js
@@ -547,19 +547,27 @@ const writeFeatures = (layer, featureProjection, mapResolution) => {
 };
 
 /**
- * Write the <Camera> tag into a KML document. Returns the KML string with added <Camera> tag
+ * Removes the <Camera> tag from a KML string. Returns the KML string with removed <Camera> tag.
  * @param {String} kmlString A string representing a KML file.
- * @param {Object} cameraAttributes Object containing the camera tags (longitude, latitude, altitude, heading, tilt, altitudeMode, roll)
- *    as keys with corresponding values. See https://developers.google.com/kml/documentation/kmlreference#camera
  */
-const writeDocumentCamera = (kmlString, cameraAttributes) => {
+const removeDocumentCamera = (kmlString) => {
   const kmlDoc = parse(kmlString);
-
   // Remove old Camera node
   const oldCameraNode = kmlDoc.getElementsByTagName('Camera')[0];
   if (oldCameraNode) {
     oldCameraNode.remove();
   }
+  return new XMLSerializer().serializeToString(kmlDoc);
+};
+
+/**
+ * Write the <Camera> tag into a KML string. Returns the KML string with added <Camera> tag.
+ * @param {String} kmlString A string representing a KML file.
+ * @param {Object} cameraAttributes Object containing the camera tags (longitude, latitude, altitude, heading, tilt, altitudeMode, roll)
+ *    as keys with corresponding values. See https://developers.google.com/kml/documentation/kmlreference#camera
+ */
+const writeDocumentCamera = (kmlString, cameraAttributes) => {
+  const kmlDoc = parse(removeDocumentCamera(kmlString));
 
   if (cameraAttributes) {
     // Create Camera node with child attributes if the cameraAttributes object is defined
@@ -602,5 +610,6 @@ export default {
   readFeatures,
   writeFeatures,
   writeDocumentCamera,
+  removeDocumentCamera,
   readDocumentCamera,
 };

--- a/src/utils/KML.test.js
+++ b/src/utils/KML.test.js
@@ -287,4 +287,60 @@ describe('KML', () => {
       expectWriteResult(feats, str);
     });
   });
+
+  describe('writeDocumentCamera()/readDocumentCamera()', () => {
+    const str = `
+      <kml ${xmlns}>
+        <Document>
+          <name>
+            CamTest
+          </name>
+        </Document>
+      </kml>`;
+
+    const strWithCam = `<kml ${xmlns}>
+        <Document>
+            <name>
+                CamTest
+            </name>
+            <Camera xmlns="">
+                <Heading>
+                    270
+                </Heading>
+                <Altitude>
+                    300
+                </Altitude>
+                <Longitude>
+                    5.8
+                </Longitude>
+                <Latitude>
+                    41.6
+                </Latitude>
+            </Camera>
+        </Document>
+      </kml>`;
+
+    test('should insert the correct <Camera> tag.', () => {
+      const kmlWithKamera = KML.writeDocumentCamera(str, {
+        heading: 270,
+        altitude: 300,
+        longitude: 5.8,
+        latitude: 41.6,
+      });
+      expect(beautify(kmlWithKamera)).toEqual(beautify(strWithCam));
+    });
+
+    test('should remove the present <Camera> tag when called without cameraAttributes.', () => {
+      const kmlWithoutKamera = KML.writeDocumentCamera(strWithCam);
+      expect(beautify(kmlWithoutKamera)).toEqual(beautify(str));
+    });
+
+    test('should read the <Camera> attributes correctly.', () => {
+      const camAttributes = KML.readDocumentCamera(strWithCam);
+      expect(camAttributes.heading).toEqual(270);
+      expect(camAttributes.altitude).toEqual(300);
+      expect(camAttributes.longitude).toEqual(5.8);
+      expect(camAttributes.latitude).toEqual(41.6);
+    });
+  });
 });

--- a/src/utils/KML.test.js
+++ b/src/utils/KML.test.js
@@ -288,7 +288,7 @@ describe('KML', () => {
     });
   });
 
-  describe('writeDocumentCamera()/readDocumentCamera()', () => {
+  describe('writeDocumentCamera()', () => {
     const str = `
       <kml ${xmlns}>
         <Document>
@@ -333,14 +333,6 @@ describe('KML', () => {
     test('should remove the present <Camera> tag when called without cameraAttributes.', () => {
       const kmlWithoutKamera = KML.writeDocumentCamera(strWithCam);
       expect(beautify(kmlWithoutKamera)).toEqual(beautify(str));
-    });
-
-    test('should read the <Camera> attributes correctly.', () => {
-      const camAttributes = KML.readDocumentCamera(strWithCam);
-      expect(camAttributes.heading).toEqual(270);
-      expect(camAttributes.altitude).toEqual(300);
-      expect(camAttributes.longitude).toEqual(5.8);
-      expect(camAttributes.latitude).toEqual(41.6);
     });
   });
 });

--- a/src/utils/KMLFormat.js
+++ b/src/utils/KMLFormat.js
@@ -1,0 +1,100 @@
+import OLKML from 'ol/format/KML';
+import {
+  parse,
+  pushParseAndPop,
+  isDocument,
+  makeStructureNS,
+  makeObjectPropertySetter,
+} from 'ol/xml';
+import { extend, includes } from 'ol/array';
+import { readDecimal, readString } from 'ol/format/xsd';
+
+const NAMESPACE_URIS = [
+  null,
+  'http://earth.google.com/kml/2.0',
+  'http://earth.google.com/kml/2.1',
+  'http://earth.google.com/kml/2.2',
+  'http://www.opengis.net/kml/2.2',
+];
+
+const CAMERA_PARSERS = makeStructureNS(NAMESPACE_URIS, {
+  Altitude: makeObjectPropertySetter(readDecimal),
+  Longitude: makeObjectPropertySetter(readDecimal),
+  Latitude: makeObjectPropertySetter(readDecimal),
+  Tilt: makeObjectPropertySetter(readDecimal),
+  AltitudeMode: makeObjectPropertySetter(readString),
+  Heading: makeObjectPropertySetter(readDecimal),
+  Roll: makeObjectPropertySetter(readDecimal),
+});
+
+class KML extends OLKML {
+  /**
+   * Read the regions of the KML.
+   *
+   * @param {Document|Element|string} source Source.
+   * @return {Array<Object>} Regions.
+   * @api
+   */
+  readCamera(source) {
+    const regions = [];
+    if (typeof source === 'string') {
+      const doc = parse(source);
+      extend(regions, this.readCameraFromDocument(doc));
+    } else if (isDocument(source)) {
+      extend(
+        regions,
+        this.readCameraFromDocument(/** @type {Document} */ (source)),
+      );
+    } else {
+      extend(regions, this.readCameraFromNode(/** @type {Element} */ (source)));
+    }
+    return regions;
+  }
+
+  /**
+   * @param {Document} doc Document.
+   * @return {Array<Object>} Region.
+   */
+  readCameraFromDocument(doc) {
+    const cameras = [];
+    for (let n = /** @type {Node} */ (doc.firstChild); n; n = n.nextSibling) {
+      if (n.nodeType === Node.ELEMENT_NODE) {
+        extend(cameras, this.readCameraFromNode(/** @type {Element} */ (n)));
+      }
+    }
+    return cameras;
+  }
+
+  /**
+   * @param {Element} node Node.
+   * @return {Array<Object>} Region.
+   * @api
+   */
+  readCameraFromNode(node) {
+    const cameras = [];
+    for (let n = node.firstElementChild; n; n = n.nextElementSibling) {
+      if (
+        includes(NAMESPACE_URIS, n.namespaceURI) &&
+        n.localName === 'Camera'
+      ) {
+        const obj = pushParseAndPop({}, CAMERA_PARSERS, n, []);
+        cameras.push(obj);
+      }
+    }
+    for (let n = node.firstElementChild; n; n = n.nextElementSibling) {
+      const { localName } = n;
+      if (
+        includes(NAMESPACE_URIS, n.namespaceURI) &&
+        (localName === 'Document' ||
+          localName === 'Folder' ||
+          localName === 'Placemark' ||
+          localName === 'kml')
+      ) {
+        extend(cameras, this.readCameraFromNode(n));
+      }
+    }
+    return cameras;
+  }
+}
+
+export default KML;

--- a/src/utils/KMLFormat.js
+++ b/src/utils/KMLFormat.js
@@ -29,31 +29,31 @@ const CAMERA_PARSERS = makeStructureNS(NAMESPACE_URIS, {
 
 class KML extends OLKML {
   /**
-   * Read the regions of the KML.
+   * Read the cameras of the KML.
    *
    * @param {Document|Element|string} source Source.
-   * @return {Array<Object>} Regions.
+   * @return {Array<Object>} Cameras.
    * @api
    */
   readCamera(source) {
-    const regions = [];
+    const cameras = [];
     if (typeof source === 'string') {
       const doc = parse(source);
-      extend(regions, this.readCameraFromDocument(doc));
+      extend(cameras, this.readCameraFromDocument(doc));
     } else if (isDocument(source)) {
       extend(
-        regions,
+        cameras,
         this.readCameraFromDocument(/** @type {Document} */ (source)),
       );
     } else {
-      extend(regions, this.readCameraFromNode(/** @type {Element} */ (source)));
+      extend(cameras, this.readCameraFromNode(/** @type {Element} */ (source)));
     }
-    return regions;
+    return cameras;
   }
 
   /**
    * @param {Document} doc Document.
-   * @return {Array<Object>} Region.
+   * @return {Array<Object>} Cameras.
    */
   readCameraFromDocument(doc) {
     const cameras = [];
@@ -67,7 +67,7 @@ class KML extends OLKML {
 
   /**
    * @param {Element} node Node.
-   * @return {Array<Object>} Region.
+   * @return {Array<Object>} Cameras.
    * @api
    */
   readCameraFromNode(node) {

--- a/src/utils/KMLFormat.test.js
+++ b/src/utils/KMLFormat.test.js
@@ -1,0 +1,53 @@
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import KML from './KMLFormat';
+
+configure({ adapter: new Adapter() });
+const xmlns =
+  'xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd"';
+
+describe('KML', () => {
+  test('should read <Camera> tags correctly.', () => {
+    const str = `
+      <kml ${xmlns}>
+        <Document>
+        <name>lala</name>
+        <Camera>
+                <Heading>
+                    270
+                </Heading>
+                <Altitude>
+                    300
+                </Altitude>
+                <Longitude>
+                    5.8
+                </Longitude>
+                <Latitude>
+                    41.6
+                </Latitude>
+            </Camera>
+            <Placemark>
+            <Camera>
+                <Heading>
+                    180
+                </Heading>
+                <AltitudeMode>
+                    clampToGround
+                </AltitudeMode>
+            </Camera>
+            </Placemark>
+        </Document>
+      </kml>
+    `;
+    const format = new KML();
+    const cameras = format.readCamera(str);
+
+    expect(cameras.length).toEqual(2);
+    expect(cameras[0].Heading).toEqual(270);
+    expect(cameras[0].Altitude).toEqual(300);
+    expect(cameras[0].Longitude).toEqual(5.8);
+    expect(cameras[0].Latitude).toEqual(41.6);
+    expect(cameras[1].Heading).toEqual(180);
+    expect(cameras[1].AltitudeMode).toEqual('clampToGround');
+  });
+});


### PR DESCRIPTION
# How to
Updates:
- readDocumentCamera
- writeDocumentCamera
- removeDocumentCamera

The new methods handle the reading and writing of <Camera> tags in the KML (contain data for View rotation, tilt etc).
See https://developers.google.com/kml/documentation/cameras?hl=en for details.

# Others

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
