### PR TITLE
chore: remove build from gh-action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,5 @@ jobs:
           yarn install --frozen-lockfile
           yarn lint
           yarn test
-          yarn build
         env:
           CI: true


### PR DESCRIPTION
# How to
yarn build removed from main gh-action (build check handled by vercel) to save gh-action minutes

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [ ] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [ ] Everything in ticket description has been fixed.
- [ ] The author of the MR has made its own review before assigning the reviewer.
- [ ] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [ ] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
