### PR TITLE
fix(LayerTree): add LayerTree renderCheckbox prop

### DIFF
--- a/src/components/LayerTree/LayerTree.js
+++ b/src/components/LayerTree/LayerTree.js
@@ -83,6 +83,11 @@ const propTypes = {
   renderLabel: PropTypes.func,
 
   /**
+   * Custom function to render the checkbox.
+   */
+  renderCheckbox: PropTypes.func,
+
+  /**
    * Object holding title for the layer tree's buttons.
    */
   titles: PropTypes.shape({
@@ -132,6 +137,7 @@ const defaultProps = {
   renderItemContent: null,
   renderBeforeItem: null,
   renderAfterItem: null,
+  renderCheckbox: null,
   renderLabel: (layer, layerComp) => {
     const { t } = layerComp.props;
     return t(layer.name);
@@ -298,7 +304,7 @@ class LayerTree extends Component {
   }
 
   renderInput(layer, inputProps) {
-    const { titles, isItemHidden } = this.props;
+    const { titles, isItemHidden, renderCheckbox } = this.props;
     let tabIndex = 0;
 
     if (
@@ -311,7 +317,9 @@ class LayerTree extends Component {
     }
 
     const inputType = layer.get("group") ? "radio" : "checkbox";
-    return (
+    return renderCheckbox ? (
+      renderCheckbox(layer, this, inputProps)
+    ) : (
       // eslint-disable-next-line jsx-a11y/label-has-associated-control,jsx-a11y/no-noninteractive-element-interactions
       <label
         className={`rs-layer-tree-input rs-layer-tree-input-${inputType} rs-${inputType}`}

--- a/src/components/LayerTree/LayerTree.test.js
+++ b/src/components/LayerTree/LayerTree.test.js
@@ -88,6 +88,14 @@ describe("LayerTree", () => {
       });
     });
 
+    test("when renderCheckbox is used.", () => {
+      renderLayerTree(layers, {
+        renderCheckbox: (l) => {
+          return <div>{l.visible ? "✓" : "✗"}</div>;
+        },
+      });
+    });
+
     test("when classNames are used.", () => {
       renderLayerTree(layers, { className: "foo" });
     });

--- a/src/components/LayerTree/README.md
+++ b/src/components/LayerTree/README.md
@@ -13,7 +13,15 @@ import BasicMap from 'react-spatial/components/BasicMap';
 const baseBright = new MapboxLayer({
   name: 'Base - Bright',
   group: 'baseLayer',
-  url: `https://maps.geops.io/styles/base_bright_v2/style.json?key=${apiKey}`,
+  url: `https://maps.geops.io/styles/travic_v2_generalized/style.json?key=${apiKey}`,
+});
+
+const stations = new MapboxStyleLayer({
+  name: 'Stations',
+  mapboxLayer: baseBright,
+  styleLayersFilter: (layer) => {
+    return layer.metadata && /mapset_stations/.test(layer.metadata['mapset.filter'])
+  }
 });
 
 const railLines = new MapboxStyleLayer({
@@ -32,31 +40,8 @@ const railLines = new MapboxStyleLayer({
   },
 });
 
-const passengerFrequencies = new MapboxStyleLayer({
-  name: 'Passenger frequencies',
-  mapboxLayer: baseBright,
-  styleLayer: {
-    id: 'passagierfrequenzen',
-    type: 'circle',
-    source: 'base',
-    'source-layer': 'osm_points',
-    filter: ['has', 'dwv'],
-    paint: {
-      'circle-radius': ['*', ['sqrt', ['/', ['get', 'dwv'], Math.PI]], 0.2],
-      'circle-color': 'rgb(254, 160, 0)',
-      'circle-stroke-width': 2,
-      'circle-stroke-color': 'rgb(254, 160, 0)',
-      'circle-opacity': [
-        'case',
-        ['boolean', ['feature-state', 'hover'], false],
-        1,
-        0.7,
-      ],
-    },
-  },
-});
 
-baseBright.children = [passengerFrequencies, railLines];
+baseBright.children = [railLines, stations];
 
 const baseDark = new MapboxLayer({
   name: 'Base - Dark',

--- a/src/components/LayerTree/README.md
+++ b/src/components/LayerTree/README.md
@@ -10,7 +10,7 @@ import GeoJSONFormat from 'ol/format/GeoJSON';
 import LayerTree from 'react-spatial/components/LayerTree';
 import BasicMap from 'react-spatial/components/BasicMap';
 
-const baseBright = new MapboxLayer({
+const baseTravic = new MapboxLayer({
   name: 'Base - Bright',
   group: 'baseLayer',
   url: `https://maps.geops.io/styles/travic_v2_generalized/style.json?key=${apiKey}`,
@@ -18,7 +18,7 @@ const baseBright = new MapboxLayer({
 
 const stations = new MapboxStyleLayer({
   name: 'Stations',
-  mapboxLayer: baseBright,
+  mapboxLayer: baseTravic,
   styleLayersFilter: (layer) => {
     return layer.metadata && /mapset_stations/.test(layer.metadata['mapset.filter'])
   }
@@ -26,7 +26,7 @@ const stations = new MapboxStyleLayer({
 
 const railLines = new MapboxStyleLayer({
   name: 'Railways routes',
-  mapboxLayer: baseBright,
+  mapboxLayer: baseTravic,
   styleLayer: {
     id: 'rail',
     type: 'line',
@@ -41,7 +41,7 @@ const railLines = new MapboxStyleLayer({
 });
 
 
-baseBright.children = [railLines, stations];
+baseTravic.children = [railLines, stations];
 
 const baseDark = new MapboxLayer({
   name: 'Base - Dark',
@@ -50,16 +50,7 @@ const baseDark = new MapboxLayer({
   url: `https://maps.geops.io/styles/base_dark_v2/style.json?key=${apiKey}`,
 });
 
-const baseTravic = new MapboxLayer({
-  url: `https://maps.geops.io/styles/travic_v2/style.json?key=${apiKey}`,
-  group: 'baseLayer',
-  visible: false,
-  properties: {
-    hidden: true,
-  },
-});
-
-const layers = [baseDark, baseTravic, baseBright];
+const layers = [baseDark, baseTravic];
 
 <div className="rs-layer-tree-example">
   <BasicMap

--- a/src/components/LayerTree/__snapshots__/LayerTree.test.js.snap
+++ b/src/components/LayerTree/__snapshots__/LayerTree.test.js.snap
@@ -1732,6 +1732,131 @@ exports[`LayerTree matches snapshots when no layers. 1`] = `
 />
 `;
 
+exports[`LayerTree matches snapshots when renderCheckbox is used. 1`] = `
+<div
+  className="rs-layer-tree"
+>
+  <div>
+    <div
+      className="rs-layer-tree-item rs-visible"
+      style={
+        {
+          "paddingLeft": "0px",
+        }
+      }
+    >
+      <div>
+        ✓
+      </div>
+      <div
+        aria-expanded={true}
+        aria-label="1 Hide sublayer"
+        className="rs-layer-tree-toggle"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        tabIndex={0}
+        title="1 Hide sublayer"
+      >
+        <div>
+          1
+        </div>
+        <div
+          className="rs-layer-tree-arrow rs-layer-tree-arrow-expanded"
+        />
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item "
+        style={
+          {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <div>
+          ✗
+        </div>
+        <div
+          aria-expanded={false}
+          aria-label="1-2 Show sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="1-2 Show sublayer"
+        >
+          <div>
+            1-2
+          </div>
+          <div
+            className="rs-layer-tree-arrow rs-layer-tree-arrow-collapsed"
+          />
+        </div>
+      </div>
+    </div>
+    <div>
+      <div
+        className="rs-layer-tree-item rs-visible"
+        style={
+          {
+            "paddingLeft": "30px",
+          }
+        }
+      >
+        <div>
+          ✓
+        </div>
+        <div
+          aria-expanded={false}
+          aria-label="1-1 Show sublayer"
+          className="rs-layer-tree-toggle"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+          title="1-1 Show sublayer"
+        >
+          <div>
+            1-1
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div
+      className="rs-layer-tree-item rs-visible"
+      style={
+        {
+          "paddingLeft": "0px",
+        }
+      }
+    >
+      <div>
+        ✓
+      </div>
+      <div
+        aria-expanded={false}
+        aria-label="root Show sublayer"
+        className="rs-layer-tree-toggle"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        tabIndex={0}
+        title="root Show sublayer"
+      >
+        <div>
+          root
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`LayerTree matches snapshots when renderItem is used. 1`] = `
 <div
   className="rs-layer-tree"


### PR DESCRIPTION
# How to
Test: 
Add 
`renderCheckbox={(l) => {
          return <div>{l.visible ? "✓" : "✗"}</div>;
        }}`
to the LayerTree props in the examples

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [ ] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
